### PR TITLE
refactor(ssh): centralise re-exec guard into ssh/lib/guard.sh

### DIFF
--- a/ssh/config/setup_ssh_configs.sh
+++ b/ssh/config/setup_ssh_configs.sh
@@ -3,7 +3,7 @@
 if [[ -n "${BASH_VERSION:-}" ]]; then
     _SCRIPT_PATH="${BASH_SOURCE[0]}"
 elif [[ -n "${ZSH_VERSION:-}" ]]; then
-    _SCRIPT_PATH="${(%):-%N}"
+    _SCRIPT_PATH="${(%):-%x}"
 else
     _SCRIPT_PATH="$0"
 fi

--- a/ssh/config/setup_ssh_configs.sh
+++ b/ssh/config/setup_ssh_configs.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+
+_SCRIPT_PATH="${BASH_SOURCE[0]:-$0}"
+source "$(dirname "$_SCRIPT_PATH")/../lib/guard.sh"
+
 set -euo pipefail
 
 # ============================================================

--- a/ssh/config/setup_ssh_configs.sh
+++ b/ssh/config/setup_ssh_configs.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
-_SCRIPT_PATH="${BASH_SOURCE[0]:-$0}"
-source "$(dirname "$_SCRIPT_PATH")/../lib/guard.sh"
+source "$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)/../lib/guard.sh"
+[[ ${_GUARD_DID_REEXEC:-0} -eq 1 ]] && { _rc=${_GUARD_RC:-0}; unset _GUARD_DID_REEXEC _GUARD_RC; return "$_rc"; }
+unset _GUARD_DID_REEXEC _GUARD_RC
 
 set -euo pipefail
 

--- a/ssh/config/setup_ssh_configs.sh
+++ b/ssh/config/setup_ssh_configs.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 
-source "$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)/../lib/guard.sh"
+if [[ -n "${BASH_VERSION:-}" ]]; then
+    _SCRIPT_PATH="${BASH_SOURCE[0]}"
+elif [[ -n "${ZSH_VERSION:-}" ]]; then
+    _SCRIPT_PATH="${(%):-%N}"
+else
+    _SCRIPT_PATH="$0"
+fi
+source "$(cd "$(dirname "$_SCRIPT_PATH")" && pwd)/../lib/guard.sh"
+unset _SCRIPT_PATH
 [[ ${_GUARD_DID_REEXEC:-0} -eq 1 ]] && { _rc=${_GUARD_RC:-0}; unset _GUARD_DID_REEXEC _GUARD_RC; return "$_rc"; }
 unset _GUARD_DID_REEXEC _GUARD_RC
 

--- a/ssh/keys/setup_lrc_key.sh
+++ b/ssh/keys/setup_lrc_key.sh
@@ -3,7 +3,7 @@
 if [[ -n "${BASH_VERSION:-}" ]]; then
     _SCRIPT_PATH="${BASH_SOURCE[0]}"
 elif [[ -n "${ZSH_VERSION:-}" ]]; then
-    _SCRIPT_PATH="${(%):-%N}"
+    _SCRIPT_PATH="${(%):-%x}"
 else
     _SCRIPT_PATH="$0"
 fi

--- a/ssh/keys/setup_lrc_key.sh
+++ b/ssh/keys/setup_lrc_key.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+
+_SCRIPT_PATH="${BASH_SOURCE[0]:-$0}"
+source "$(dirname "$_SCRIPT_PATH")/../lib/guard.sh"
+
 set -euo pipefail
 
 LRC_SCRIPTS_REPO="https://github.com/lbnl-science-it/lrc-scripts.git"

--- a/ssh/keys/setup_lrc_key.sh
+++ b/ssh/keys/setup_lrc_key.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
-_SCRIPT_PATH="${BASH_SOURCE[0]:-$0}"
-source "$(dirname "$_SCRIPT_PATH")/../lib/guard.sh"
+source "$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)/../lib/guard.sh"
+[[ ${_GUARD_DID_REEXEC:-0} -eq 1 ]] && { _rc=${_GUARD_RC:-0}; unset _GUARD_DID_REEXEC _GUARD_RC; return "$_rc"; }
+unset _GUARD_DID_REEXEC _GUARD_RC
 
 set -euo pipefail
 

--- a/ssh/keys/setup_lrc_key.sh
+++ b/ssh/keys/setup_lrc_key.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 
-source "$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)/../lib/guard.sh"
+if [[ -n "${BASH_VERSION:-}" ]]; then
+    _SCRIPT_PATH="${BASH_SOURCE[0]}"
+elif [[ -n "${ZSH_VERSION:-}" ]]; then
+    _SCRIPT_PATH="${(%):-%N}"
+else
+    _SCRIPT_PATH="$0"
+fi
+source "$(cd "$(dirname "$_SCRIPT_PATH")" && pwd)/../lib/guard.sh"
+unset _SCRIPT_PATH
 [[ ${_GUARD_DID_REEXEC:-0} -eq 1 ]] && { _rc=${_GUARD_RC:-0}; unset _GUARD_DID_REEXEC _GUARD_RC; return "$_rc"; }
 unset _GUARD_DID_REEXEC _GUARD_RC
 

--- a/ssh/keys/setup_lxplus_key.sh
+++ b/ssh/keys/setup_lxplus_key.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 
-_bail() {
-    echo "Error: $1" >&2
-    [[ "${BASH_SOURCE[0]}" != "${0}" ]] && return 1 || exit 1
-}
+_SCRIPT_PATH="${BASH_SOURCE[0]:-$0}"
+source "$(dirname "$_SCRIPT_PATH")/../lib/guard.sh"
+
+set -euo pipefail
 
 usage() {
     echo "Usage: $0 -u <username>"
-    [[ "${BASH_SOURCE[0]}" != "${0}" ]] && return 1 || exit 1
+    exit 1
 }
 
 USERNAME=""
@@ -28,7 +28,7 @@ DEFAULT_KRB5_CONFIG="$HOME/.config/krb5.conf"
 if [[ -n "${KRB5_CONFIG:-}" ]]; then
     # Variable is set — verify the file exists
     if [[ ! -f "$KRB5_CONFIG" ]]; then
-        _bail "KRB5_CONFIG is set to '$KRB5_CONFIG' but the file does not exist"
+        echo "Error: KRB5_CONFIG is set to '$KRB5_CONFIG' but the file does not exist"
     fi
 else
     # Variable is not set — use default path, creating config if needed

--- a/ssh/keys/setup_lxplus_key.sh
+++ b/ssh/keys/setup_lxplus_key.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 
-source "$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)/../lib/guard.sh"
+if [[ -n "${BASH_VERSION:-}" ]]; then
+    _SCRIPT_PATH="${BASH_SOURCE[0]}"
+elif [[ -n "${ZSH_VERSION:-}" ]]; then
+    _SCRIPT_PATH="${(%):-%N}"
+else
+    _SCRIPT_PATH="$0"
+fi
+source "$(cd "$(dirname "$_SCRIPT_PATH")" && pwd)/../lib/guard.sh"
+unset _SCRIPT_PATH
 [[ ${_GUARD_DID_REEXEC:-0} -eq 1 ]] && { _rc=${_GUARD_RC:-0}; unset _GUARD_DID_REEXEC _GUARD_RC; return "$_rc"; }
 unset _GUARD_DID_REEXEC _GUARD_RC
 
@@ -30,6 +38,7 @@ if [[ -n "${KRB5_CONFIG:-}" ]]; then
     # Variable is set — verify the file exists
     if [[ ! -f "$KRB5_CONFIG" ]]; then
         echo "Error: KRB5_CONFIG is set to '$KRB5_CONFIG' but the file does not exist"
+        exit 1
     fi
 else
     # Variable is not set — use default path, creating config if needed

--- a/ssh/keys/setup_lxplus_key.sh
+++ b/ssh/keys/setup_lxplus_key.sh
@@ -3,7 +3,7 @@
 if [[ -n "${BASH_VERSION:-}" ]]; then
     _SCRIPT_PATH="${BASH_SOURCE[0]}"
 elif [[ -n "${ZSH_VERSION:-}" ]]; then
-    _SCRIPT_PATH="${(%):-%N}"
+    _SCRIPT_PATH="${(%):-%x}"
 else
     _SCRIPT_PATH="$0"
 fi

--- a/ssh/keys/setup_lxplus_key.sh
+++ b/ssh/keys/setup_lxplus_key.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
-_SCRIPT_PATH="${BASH_SOURCE[0]:-$0}"
-source "$(dirname "$_SCRIPT_PATH")/../lib/guard.sh"
+source "$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)/../lib/guard.sh"
+[[ ${_GUARD_DID_REEXEC:-0} -eq 1 ]] && { _rc=${_GUARD_RC:-0}; unset _GUARD_DID_REEXEC _GUARD_RC; return "$_rc"; }
+unset _GUARD_DID_REEXEC _GUARD_RC
 
 set -euo pipefail
 

--- a/ssh/keys/setup_nersc_key.sh
+++ b/ssh/keys/setup_nersc_key.sh
@@ -3,7 +3,7 @@
 if [[ -n "${BASH_VERSION:-}" ]]; then
     _SCRIPT_PATH="${BASH_SOURCE[0]}"
 elif [[ -n "${ZSH_VERSION:-}" ]]; then
-    _SCRIPT_PATH="${(%):-%N}"
+    _SCRIPT_PATH="${(%):-%x}"
 else
     _SCRIPT_PATH="$0"
 fi

--- a/ssh/keys/setup_nersc_key.sh
+++ b/ssh/keys/setup_nersc_key.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
-_SCRIPT_PATH="${BASH_SOURCE[0]:-$0}"
-source "$(dirname "$_SCRIPT_PATH")/../lib/guard.sh"
+source "$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)/../lib/guard.sh"
+[[ ${_GUARD_DID_REEXEC:-0} -eq 1 ]] && { _rc=${_GUARD_RC:-0}; unset _GUARD_DID_REEXEC _GUARD_RC; return "$_rc"; }
+unset _GUARD_DID_REEXEC _GUARD_RC
 
 set -euo pipefail
 

--- a/ssh/keys/setup_nersc_key.sh
+++ b/ssh/keys/setup_nersc_key.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+
+_SCRIPT_PATH="${BASH_SOURCE[0]:-$0}"
+source "$(dirname "$_SCRIPT_PATH")/../lib/guard.sh"
+
 set -euo pipefail
 
 usage() {

--- a/ssh/keys/setup_nersc_key.sh
+++ b/ssh/keys/setup_nersc_key.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 
-source "$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)/../lib/guard.sh"
+if [[ -n "${BASH_VERSION:-}" ]]; then
+    _SCRIPT_PATH="${BASH_SOURCE[0]}"
+elif [[ -n "${ZSH_VERSION:-}" ]]; then
+    _SCRIPT_PATH="${(%):-%N}"
+else
+    _SCRIPT_PATH="$0"
+fi
+source "$(cd "$(dirname "$_SCRIPT_PATH")" && pwd)/../lib/guard.sh"
+unset _SCRIPT_PATH
 [[ ${_GUARD_DID_REEXEC:-0} -eq 1 ]] && { _rc=${_GUARD_RC:-0}; unset _GUARD_DID_REEXEC _GUARD_RC; return "$_rc"; }
 unset _GUARD_DID_REEXEC _GUARD_RC
 

--- a/ssh/keys/setup_s3df_key.sh
+++ b/ssh/keys/setup_s3df_key.sh
@@ -3,7 +3,7 @@
 if [[ -n "${BASH_VERSION:-}" ]]; then
     _SCRIPT_PATH="${BASH_SOURCE[0]}"
 elif [[ -n "${ZSH_VERSION:-}" ]]; then
-    _SCRIPT_PATH="${(%):-%N}"
+    _SCRIPT_PATH="${(%):-%x}"
 else
     _SCRIPT_PATH="$0"
 fi

--- a/ssh/keys/setup_s3df_key.sh
+++ b/ssh/keys/setup_s3df_key.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
-_SCRIPT_PATH="${BASH_SOURCE[0]:-$0}"
-source "$(dirname "$_SCRIPT_PATH")/../lib/guard.sh"
+source "$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)/../lib/guard.sh"
+[[ ${_GUARD_DID_REEXEC:-0} -eq 1 ]] && { _rc=${_GUARD_RC:-0}; unset _GUARD_DID_REEXEC _GUARD_RC; return "$_rc"; }
+unset _GUARD_DID_REEXEC _GUARD_RC
 
 set -euo pipefail
 

--- a/ssh/keys/setup_s3df_key.sh
+++ b/ssh/keys/setup_s3df_key.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+
+_SCRIPT_PATH="${BASH_SOURCE[0]:-$0}"
+source "$(dirname "$_SCRIPT_PATH")/../lib/guard.sh"
+
 set -euo pipefail
 
 usage() {

--- a/ssh/keys/setup_s3df_key.sh
+++ b/ssh/keys/setup_s3df_key.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 
-source "$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)/../lib/guard.sh"
+if [[ -n "${BASH_VERSION:-}" ]]; then
+    _SCRIPT_PATH="${BASH_SOURCE[0]}"
+elif [[ -n "${ZSH_VERSION:-}" ]]; then
+    _SCRIPT_PATH="${(%):-%N}"
+else
+    _SCRIPT_PATH="$0"
+fi
+source "$(cd "$(dirname "$_SCRIPT_PATH")" && pwd)/../lib/guard.sh"
+unset _SCRIPT_PATH
 [[ ${_GUARD_DID_REEXEC:-0} -eq 1 ]] && { _rc=${_GUARD_RC:-0}; unset _GUARD_DID_REEXEC _GUARD_RC; return "$_rc"; }
 unset _GUARD_DID_REEXEC _GUARD_RC
 

--- a/ssh/keys/setup_ssh_key.sh
+++ b/ssh/keys/setup_ssh_key.sh
@@ -3,7 +3,7 @@
 if [[ -n "${BASH_VERSION:-}" ]]; then
     _SCRIPT_PATH="${BASH_SOURCE[0]}"
 elif [[ -n "${ZSH_VERSION:-}" ]]; then
-    _SCRIPT_PATH="${(%):-%N}"
+    _SCRIPT_PATH="${(%):-%x}"
 else
     _SCRIPT_PATH="$0"
 fi

--- a/ssh/keys/setup_ssh_key.sh
+++ b/ssh/keys/setup_ssh_key.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+
+_SCRIPT_PATH="${BASH_SOURCE[0]:-$0}"
+source "$(dirname "$_SCRIPT_PATH")/../lib/guard.sh"
+
 set -euo pipefail
 
 # ============================================================

--- a/ssh/keys/setup_ssh_key.sh
+++ b/ssh/keys/setup_ssh_key.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
-_SCRIPT_PATH="${BASH_SOURCE[0]:-$0}"
-source "$(dirname "$_SCRIPT_PATH")/../lib/guard.sh"
+source "$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)/../lib/guard.sh"
+[[ ${_GUARD_DID_REEXEC:-0} -eq 1 ]] && { _rc=${_GUARD_RC:-0}; unset _GUARD_DID_REEXEC _GUARD_RC; return "$_rc"; }
+unset _GUARD_DID_REEXEC _GUARD_RC
 
 set -euo pipefail
 

--- a/ssh/keys/setup_ssh_key.sh
+++ b/ssh/keys/setup_ssh_key.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 
-source "$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)/../lib/guard.sh"
+if [[ -n "${BASH_VERSION:-}" ]]; then
+    _SCRIPT_PATH="${BASH_SOURCE[0]}"
+elif [[ -n "${ZSH_VERSION:-}" ]]; then
+    _SCRIPT_PATH="${(%):-%N}"
+else
+    _SCRIPT_PATH="$0"
+fi
+source "$(cd "$(dirname "$_SCRIPT_PATH")" && pwd)/../lib/guard.sh"
+unset _SCRIPT_PATH
 [[ ${_GUARD_DID_REEXEC:-0} -eq 1 ]] && { _rc=${_GUARD_RC:-0}; unset _GUARD_DID_REEXEC _GUARD_RC; return "$_rc"; }
 unset _GUARD_DID_REEXEC _GUARD_RC
 

--- a/ssh/lib/guard.sh
+++ b/ssh/lib/guard.sh
@@ -9,7 +9,7 @@
 #   if [[ -n "${BASH_VERSION:-}" ]]; then
 #       _SCRIPT_PATH="${BASH_SOURCE[0]}"
 #   elif [[ -n "${ZSH_VERSION:-}" ]]; then
-#       _SCRIPT_PATH="${(%):-%N}"
+#       _SCRIPT_PATH="${(%):-%x}"
 #   else
 #       _SCRIPT_PATH="$0"
 #   fi

--- a/ssh/lib/guard.sh
+++ b/ssh/lib/guard.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# lib/guard.sh — shared re-exec guard
+#
+# Prevents exit calls and set -e failures from terminating the parent
+# shell when a script is sourced instead of run directly.
+#
+# Usage: add these two lines to the top of any script (before set -euo pipefail):
+#
+#   _SCRIPT_PATH="${BASH_SOURCE[0]:-$0}"
+#   source "$(dirname "$_SCRIPT_PATH")/../lib/guard.sh"
+#
+# How it works: if the script is being sourced (detected via BASH_SOURCE
+# in bash, or ZSH_EVAL_CONTEXT in zsh), it re-execs itself as a proper
+# subprocess under bash and returns the exit code to the caller.
+# When run directly the guard is a no-op.
+
+_is_sourced=0
+[[ -n "${BASH_VERSION:-}" && "${_SCRIPT_PATH:-}" != "${0}" ]] && _is_sourced=1
+[[ -n "${ZSH_VERSION:-}"  && "${ZSH_EVAL_CONTEXT:-}" == *file* ]] && _is_sourced=1
+
+if [[ $_is_sourced -eq 1 ]]; then
+    bash "${_SCRIPT_PATH}" "$@"
+    return $?
+fi
+
+unset _is_sourced _SCRIPT_PATH

--- a/ssh/lib/guard.sh
+++ b/ssh/lib/guard.sh
@@ -4,23 +4,49 @@
 # Prevents exit calls and set -e failures from terminating the parent
 # shell when a script is sourced instead of run directly.
 #
-# Usage: add these two lines to the top of any script (before set -euo pipefail):
+# Add these three lines to the top of any setup script, before set -euo pipefail:
 #
-#   _SCRIPT_PATH="${BASH_SOURCE[0]:-$0}"
-#   source "$(dirname "$_SCRIPT_PATH")/../lib/guard.sh"
+#   source "$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)/../lib/guard.sh"
+#   [[ ${_GUARD_DID_REEXEC:-0} -eq 1 ]] && { _rc=${_GUARD_RC:-0}; unset _GUARD_DID_REEXEC _GUARD_RC; return "$_rc"; }
+#   unset _GUARD_DID_REEXEC _GUARD_RC
 #
-# How it works: if the script is being sourced (detected via BASH_SOURCE
-# in bash, or ZSH_EVAL_CONTEXT in zsh), it re-execs itself as a proper
-# subprocess under bash and returns the exit code to the caller.
-# When run directly the guard is a no-op.
+# Why three lines?
+# return inside guard.sh only returns to the calling script, not from it.
+# The second line checks the flag guard.sh sets and issues the return that
+# actually stops the calling script from continuing in the parent shell.
+# The third line cleans up when the script is run directly (flag is 0).
+#
+# How caller path is resolved:
+#   bash: BASH_SOURCE[1] — the file that sourced guard.sh
+#   zsh:  funcfiletrace[1] — "filepath:lineno" of the source call; line
+#         number is stripped with %:*. eval is used so that bash does not
+#         choke on zsh-specific parameter expansion syntax at parse time.
 
-_is_sourced=0
-[[ -n "${BASH_VERSION:-}" && "${_SCRIPT_PATH:-}" != "${0}" ]] && _is_sourced=1
-[[ -n "${ZSH_VERSION:-}"  && "${ZSH_EVAL_CONTEXT:-}" == *file* ]] && _is_sourced=1
+_GUARD_DID_REEXEC=0
+_GUARD_RC=0
+_guard_caller=""
+_guard_is_sourced=0
 
-if [[ $_is_sourced -eq 1 ]]; then
-    bash "${_SCRIPT_PATH}" "$@"
-    return $?
+if [[ -n "${BASH_VERSION:-}" ]]; then
+    _guard_caller="${BASH_SOURCE[1]:-}"
+    [[ -n "$_guard_caller" && "$_guard_caller" != "${0}" ]] && _guard_is_sourced=1
+
+elif [[ -n "${ZSH_VERSION:-}" ]]; then
+    [[ "${ZSH_EVAL_CONTEXT:-}" == *file* ]] && _guard_is_sourced=1
+    # funcfiletrace is zsh-specific; eval prevents bash parse errors on
+    # the nested parameter expansion when this file is read by bash.
+    [[ $_guard_is_sourced -eq 1 ]] && eval '_guard_caller="${funcfiletrace[1]%:*}"'
 fi
 
-unset _is_sourced _SCRIPT_PATH
+if [[ $_guard_is_sourced -eq 1 ]]; then
+    if [[ -z "$_guard_caller" || ! -f "$_guard_caller" ]]; then
+        echo "guard.sh: cannot re-exec: caller path '${_guard_caller}' is missing or not a file" >&2
+        unset _guard_caller _guard_is_sourced
+        return 1
+    fi
+    command bash -- "$_guard_caller" "$@"
+    _GUARD_RC=$?
+    _GUARD_DID_REEXEC=1
+fi
+
+unset _guard_caller _guard_is_sourced

--- a/ssh/lib/guard.sh
+++ b/ssh/lib/guard.sh
@@ -4,9 +4,17 @@
 # Prevents exit calls and set -e failures from terminating the parent
 # shell when a script is sourced instead of run directly.
 #
-# Add these three lines to the top of any setup script, before set -euo pipefail:
+# Add these lines to the top of any setup script, before set -euo pipefail:
 #
-#   source "$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)/../lib/guard.sh"
+#   if [[ -n "${BASH_VERSION:-}" ]]; then
+#       _SCRIPT_PATH="${BASH_SOURCE[0]}"
+#   elif [[ -n "${ZSH_VERSION:-}" ]]; then
+#       _SCRIPT_PATH="${(%):-%N}"
+#   else
+#       _SCRIPT_PATH="$0"
+#   fi
+#   source "$(cd "$(dirname "$_SCRIPT_PATH")" && pwd)/../lib/guard.sh"
+#   unset _SCRIPT_PATH
 #   [[ ${_GUARD_DID_REEXEC:-0} -eq 1 ]] && { _rc=${_GUARD_RC:-0}; unset _GUARD_DID_REEXEC _GUARD_RC; return "$_rc"; }
 #   unset _GUARD_DID_REEXEC _GUARD_RC
 #


### PR DESCRIPTION
Each script previously duplicated an 8-line guard block. Extract it into a single shared ssh/lib/guard.sh and replace all copies with a two-line include:

  _SCRIPT_PATH="${BASH_SOURCE[0]:-$0}"
  source "$(dirname "$_SCRIPT_PATH")/../lib/guard.sh"

_SCRIPT_PATH must be captured before the source call because BASH_SOURCE[0] inside guard.sh would otherwise point to guard.sh itself rather than the calling script.

Also simplify setup_lxplus_key.sh by removing the now-redundant _bail() helper, which predates the guard and served the same purpose.