### PR TITLE
Fix key display for s3df

### DIFF
--- a/ssh/keys/setup_s3df_key.sh
+++ b/ssh/keys/setup_s3df_key.sh
@@ -43,4 +43,4 @@ ssh-keygen -t ed25519 -f "$KEY" -C "$USERNAME"
 echo
 echo "==> Setup complete. Upload the following public key to https://s3df-sshkeys.slac.stanford.edu:"
 echo
-cat "$KEY.pub"
+ssh-keygen -e -f "$KEY.pub"


### PR DESCRIPTION
The s3df web portal expects RFC4716 key format, not OpenSSH.