### PR TITLE
Fix ssh-remote-status time formatting and lxplus klist parsing

### DIFF
--- a/ssh/keys/status_ssh_keys.sh
+++ b/ssh/keys/status_ssh_keys.sh
@@ -14,15 +14,47 @@ _ok()     { echo -e "  ${GREEN}✔${RESET}  $1"; }
 _warn()   { echo -e "  ${YELLOW}⚠${RESET}  $1"; }
 _err()    { echo -e "  ${RED}✘${RESET}  $1"; }
 
+# Convert an epoch timestamp to "YYYY-MM-DD HH:MM:SS"
+_fmt_date() {
+    date -r "$1" "+%Y-%m-%d %H:%M:%S" 2>/dev/null \
+        || date -d "@$1" "+%Y-%m-%d %H:%M:%S" 2>/dev/null \
+        || echo "(unknown)"
+}
+
+# Format remaining seconds as "Xh Ym"
+_fmt_remaining() {
+    local secs=$(( $1 ))
+    echo "$(( secs / 3600 ))h $(( (secs % 3600) / 60 ))m"
+}
+
 # ── lxplus (Kerberos) ────────────────────────────────────────
 _header "lxplus / CERN (Kerberos)"
 if command -v klist &>/dev/null; then
     KLIST=$(klist 2>&1)
-    if echo "$KLIST" | grep -q "Credentials cache"; then
-        EXPIRY=$(echo "$KLIST" | grep "krbtgt/CERN.CH" | awk '{print $3, $4}' | head -1)
+    if echo "$KLIST" | grep -qE "Credentials cache|Ticket cache"; then
+        EXPIRY_LINE=$(echo "$KLIST" | grep "krbtgt/CERN.CH" | head -1)
+        # macOS Heimdal: "Dec 10 13:38:50 2026  krbtgt/..."  → expiry in fields $1-$4
+        # Linux MIT:     "05/12/2026 15:51:12  05/13/2026 15:51:01  krbtgt/..." → expiry in fields $3-$4
+        if echo "$EXPIRY_LINE" | grep -qE '^[A-Za-z]{3} '; then
+            EXPIRY_RAW=$(echo "$EXPIRY_LINE" | awk '{print $1, $2, $3, $4}')
+            EXPIRY_EPOCH=$(date -j -f "%b %d %T %Y" "$EXPIRY_RAW" "+%s" 2>/dev/null || echo "")
+        else
+            EXPIRY_RAW=$(echo "$EXPIRY_LINE" | awk '{print $3, $4}')
+            EXPIRY_EPOCH=$(date -d "$EXPIRY_RAW" "+%s" 2>/dev/null || echo "")
+        fi
+        NOW_EPOCH=$(date "+%s")
+
+        if [[ -n "$EXPIRY_EPOCH" && "$NOW_EPOCH" -lt "$EXPIRY_EPOCH" ]]; then
+            EXPIRY_FMT=$(_fmt_date "$EXPIRY_EPOCH")
+            REMAINING=$(_fmt_remaining $(( EXPIRY_EPOCH - NOW_EPOCH )))
+            _ok "Valid ticket — expires $EXPIRY_FMT ($REMAINING remaining)"
+        else
+            EXPIRY_FMT=$(_fmt_date "$EXPIRY_EPOCH")
+            _err "Ticket expired ($EXPIRY_FMT) — run: ssh-remote-auth --host lxplus -u <username>"
+        fi
+
         # $(NF-1) gets the flags field regardless of date format variations across OSes
         FLAGS=$(klist -f 2>/dev/null | grep "krbtgt/CERN.CH" | awk '{print $(NF-1)}' | head -1)
-        _ok "Valid ticket — expires $EXPIRY"
         if echo "$FLAGS" | grep -q "F"; then
             _ok "Ticket is forwardable — credentials will be delegated to lxplus"
         else
@@ -31,7 +63,7 @@ if command -v klist &>/dev/null; then
             _warn "Check 'forwardable = true' is in your krb5.conf, then re-run: ssh-remote-auth --host lxplus -u <username>"
         fi
     else
-        _err "No valid Kerberos ticket — run: ./setup_ssh_key.sh --host lxplus -u <username>"
+        _err "No valid Kerberos ticket — run: ssh-remote-auth --host lxplus -u <username>"
     fi
 else
     _warn "klist not found — Kerberos tools may not be installed"
@@ -41,20 +73,20 @@ fi
 _header "NERSC (sshproxy certificate)"
 NERSC_CERT="$HOME/.ssh/nersc-cert.pub"
 if [[ -f "$NERSC_CERT" ]]; then
-    VALIDITY=$(ssh-keygen -L -f "$NERSC_CERT" 2>/dev/null | grep "Valid:")
-    # Extract the expiry date from "Valid: from ... to YYYY-MM-DDTHH:MM:SS"
-    EXPIRY=$(echo "$VALIDITY" | sed 's/.*to //')
-    EXPIRY_EPOCH=$(date -j -f "%Y-%m-%dT%H:%M:%S" "$EXPIRY" "+%s" 2>/dev/null \
-        || date -d "$EXPIRY" "+%s" 2>/dev/null || echo "")
+    EXPIRY_RAW=$(ssh-keygen -L -f "$NERSC_CERT" 2>/dev/null | awk '/Valid:/{print $NF}')
+    EXPIRY_EPOCH=$(date -j -f "%Y-%m-%dT%H:%M:%S" "$EXPIRY_RAW" "+%s" 2>/dev/null \
+        || date -d "$EXPIRY_RAW" "+%s" 2>/dev/null || echo "")
     NOW_EPOCH=$(date "+%s")
     if [[ -n "$EXPIRY_EPOCH" && "$NOW_EPOCH" -lt "$EXPIRY_EPOCH" ]]; then
-        REMAINING=$(( (EXPIRY_EPOCH - NOW_EPOCH) / 3600 ))
-        _ok "Valid certificate — expires $EXPIRY (${REMAINING}h remaining)"
+        EXPIRY_FMT=$(_fmt_date "$EXPIRY_EPOCH")
+        REMAINING=$(_fmt_remaining $(( EXPIRY_EPOCH - NOW_EPOCH )))
+        _ok "Valid certificate — expires $EXPIRY_FMT ($REMAINING remaining)"
     else
-        _err "Certificate expired ($EXPIRY) — run: ./setup_ssh_key.sh --host nersc -u <username>"
+        EXPIRY_FMT=$(_fmt_date "$EXPIRY_EPOCH")
+        _err "Certificate expired ($EXPIRY_FMT) — run: ssh-remote-auth --host nersc -u <username>"
     fi
 else
-    _err "No certificate found at $NERSC_CERT — run: ./setup_ssh_key.sh --host nersc -u <username>"
+    _err "No certificate found at $NERSC_CERT — run: ssh-remote-auth --host nersc -u <username>"
 fi
 
 # ── LRC / Lawrencium (SSH certificate) ───────────────────────
@@ -62,32 +94,34 @@ _header "LRC / Lawrencium (SSH certificate)"
 LRC_CERT="$HOME/.ssh/ssh_certs/lrc_cert-cert.pub"
 LRC_KEY="$HOME/.ssh/ssh_certs/lrc_cert"
 if [[ -f "$LRC_CERT" ]]; then
-    VALIDITY=$(ssh-keygen -L -f "$LRC_CERT" 2>/dev/null | grep "Valid:")
-    EXPIRY=$(echo "$VALIDITY" | sed 's/.*to //')
-    EXPIRY_EPOCH=$(date -j -f "%Y-%m-%dT%H:%M:%S" "$EXPIRY" "+%s" 2>/dev/null \
-        || date -d "$EXPIRY" "+%s" 2>/dev/null || echo "")
+    EXPIRY_RAW=$(ssh-keygen -L -f "$LRC_CERT" 2>/dev/null | awk '/Valid:/{print $NF}')
+    EXPIRY_EPOCH=$(date -j -f "%Y-%m-%dT%H:%M:%S" "$EXPIRY_RAW" "+%s" 2>/dev/null \
+        || date -d "$EXPIRY_RAW" "+%s" 2>/dev/null || echo "")
     NOW_EPOCH=$(date "+%s")
     if [[ -n "$EXPIRY_EPOCH" && "$NOW_EPOCH" -lt "$EXPIRY_EPOCH" ]]; then
-        REMAINING=$(( (EXPIRY_EPOCH - NOW_EPOCH) / 3600 ))
-        _ok "Valid certificate — expires $EXPIRY (${REMAINING}h remaining)"
+        EXPIRY_FMT=$(_fmt_date "$EXPIRY_EPOCH")
+        REMAINING=$(_fmt_remaining $(( EXPIRY_EPOCH - NOW_EPOCH )))
+        _ok "Valid certificate — expires $EXPIRY_FMT ($REMAINING remaining)"
     else
-        _err "Certificate expired ($EXPIRY) — run: ./setup_ssh_key.sh --host lrc"
+        EXPIRY_FMT=$(_fmt_date "$EXPIRY_EPOCH")
+        _err "Certificate expired ($EXPIRY_FMT) — run: ssh-remote-auth --host lrc"
     fi
 elif [[ -f "$LRC_KEY" ]]; then
-    _warn "Key found but no certificate at $LRC_CERT — run: ./setup_ssh_key.sh --host lrc"
+    _warn "Key found but no certificate at $LRC_CERT — run: ssh-remote-auth --host lrc"
 else
-    _err "No key or certificate found — run: ./setup_ssh_key.sh --host lrc"
+    _err "No key or certificate found — run: ssh-remote-auth --host lrc"
 fi
 
 # ── S3DF / SLAC (SSH key) ─────────────────────────────────────
 _header "S3DF / SLAC (SSH key)"
 S3DF_KEY="$HOME/.ssh/s3df/key"
 if [[ -f "$S3DF_KEY" ]]; then
-    CREATED=$(date -r "$S3DF_KEY" "+%Y-%m-%d %H:%M" 2>/dev/null || stat -c "%y" "$S3DF_KEY" 2>/dev/null)
+    MTIME=$(stat -f "%m" "$S3DF_KEY" 2>/dev/null || stat -c "%Y" "$S3DF_KEY" 2>/dev/null)
+    CREATED=$(_fmt_date "$MTIME")
     _ok "Key present — created $CREATED"
     _warn "S3DF keys expire periodically — re-register at https://s3df-sshkeys.slac.stanford.edu if login fails"
 else
-    _err "No key found at $S3DF_KEY — run: ./setup_ssh_key.sh --host s3df -u <username>"
+    _err "No key found at $S3DF_KEY — run: ssh-remote-auth --host s3df -u <username>"
 fi
 
 echo


### PR DESCRIPTION
## Summary
Fixes several bugs in `status_ssh_keys.sh` and unifies the output
format across all facilities.

## Changes

### Unified date/time format
All expiry and creation timestamps now display as `YYYY-MM-DD HH:MM:SS`
with time remaining shown as `Xh Ym`. Two shared helpers centralise
the formatting logic so date conversion and remaining-time arithmetic
are not repeated per facility.

### lxplus klist parsing
- **Cache label**: also matches `Ticket cache` used by Linux MIT
  Kerberos (previously only matched `Credentials cache` from macOS
  Heimdal), so the ticket check was silently skipped on Linux
- **Date format**: detects macOS Heimdal (`Dec 10 13:38:50 2026`,
  expiry in `$1–$4`) vs Linux MIT (`05/13/2026 15:51:01`, expiry
  in `$3–$4`) and parses each accordingly
- **Flags extraction**: `awk '{print $1}'` was grabbing a date field,
  causing the forwardable check to always report false; fixed to
  `awk '{print $(NF-1)}'`

### Forwardable ticket message
Reworded from the misleading "re-run setup_lxplus_key.sh" to explain
that SSH login still works, that credential delegation is what is
affected, and that the fix is to check `forwardable = true` in
`krb5.conf`.

## Output before / after

Before:
  ✔  Valid ticket — expires 13:38:50 2026
  ⚠  Ticket is NOT forwardable — re-run setup_lxplus_key.sh
  ✔  Valid certificate — expires 2026-05-13T15:37:40 (23h remaining)
  ✘  Certificate expired (2026-05-12T00:58:47)

After:
  ✔  Valid ticket — expires 2026-05-13 13:38:50 (23h 21m remaining)
  ✔  Ticket is forwardable — credentials will be delegated to lxplus
  ✔  Valid certificate — expires 2026-05-13 15:37:40 (23h 20m remaining)
  ✘  Certificate expired (2026-05-12 00:58:47) — run: ssh-remote-auth ...