### PR TITLE
[feat] Windows support for ssh-remote-auth (Git Bash / MSYS2 / WSL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,25 @@ ssh/
 
 | Facility | Requirement |
 |----------|-------------|
-| lxplus   | Kerberos client (`kinit`, `klist`) — pre-installed on macOS; `krb5-user` on Debian/Ubuntu |
+| lxplus   | Kerberos client (`kinit`, `klist`) — pre-installed on macOS; `krb5-user` on Debian/Ubuntu; [MIT Kerberos for Windows](https://web.mit.edu/kerberos/dist/) on Windows |
 | NERSC    | `curl` — `sshproxy` binary is auto-downloaded on first run |
 | LRC      | `git` — `lrc-scripts` repo is auto-cloned on first run |
 | S3DF     | `ssh-keygen` — standard, pre-installed everywhere |
+
+#### Windows
+
+The scripts are bash and run on Windows under **Git Bash** (or
+MSYS2/Cygwin) and **WSL**. WSL behaves exactly like Linux and needs
+nothing special. Under Git Bash:
+
+- **lxplus** — install MIT Kerberos for Windows first so `kinit` is on
+  PATH. The generated config at `~/.config/krb5.conf` is passed to
+  `kinit` via `KRB5_CONFIG` in Windows path form automatically.
+- **NERSC** — the `windows-universal` MSIX package is downloaded from
+  the NERSC portal and installed per-user via `Add-AppxPackage` (no
+  admin rights needed). The `sshproxy` command then resolves from
+  `%LOCALAPPDATA%\Microsoft\WindowsApps`.
+- **LRC / S3DF** — work as-is; `git` and `ssh-keygen` ship with Git Bash.
 
 ### Installation
 

--- a/ssh/keys/setup_lrc_key.sh
+++ b/ssh/keys/setup_lrc_key.sh
@@ -20,12 +20,12 @@ else
     git clone "$LRC_SCRIPTS_REPO" "$LRC_SCRIPTS_DIR"
 fi
 
-# Ensure the script is executable regardless of how it was cloned
+# Run through bash rather than relying on the exec bit — chmod +x is
+# not reliably honored on Windows filesystems (Git Bash / NTFS).
 if [[ ! -f "$REQUEST_CERT" ]]; then
     echo "Error: request_cert.sh not found in $LRC_SCRIPTS_DIR after clone/pull"
     echo "       The repository structure may have changed — check $LRC_SCRIPTS_REPO"
     exit 1
 fi
-chmod +x "$REQUEST_CERT"
 
-"$REQUEST_CERT" -p lrc
+bash "$REQUEST_CERT" -p lrc

--- a/ssh/keys/setup_lxplus_key.sh
+++ b/ssh/keys/setup_lxplus_key.sh
@@ -23,6 +23,34 @@ if [[ -z "$USERNAME" ]]; then
     usage
 fi
 
+# ── Platform detection ───────────────────────────────────────
+# Git Bash / MSYS2 / Cygwin report MINGW*/MSYS*/CYGWIN*; WSL
+# reports Linux and needs no special handling.
+case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*) IS_WINDOWS=true ;;
+    *)                    IS_WINDOWS=false ;;
+esac
+
+# Convert a POSIX path to the platform-native form. Native Windows
+# programs (e.g. MIT kinit.exe) cannot open MSYS-style /c/Users/...
+# paths, and MSYS auto-converts command-line arguments only — not
+# arbitrary environment variables like KRB5_CONFIG.
+_native_path() {
+    if [[ "$IS_WINDOWS" == true ]] && command -v cygpath &>/dev/null; then
+        cygpath -w "$1"
+    else
+        printf '%s' "$1"
+    fi
+}
+
+if ! command -v kinit &>/dev/null; then
+    if [[ "$IS_WINDOWS" == true ]]; then
+        _bail "kinit not found. Install MIT Kerberos for Windows (https://web.mit.edu/kerberos/dist/), then open a new terminal so kinit.exe is on PATH"
+    else
+        _bail "kinit not found. Install a Kerberos client (krb5-user on Debian/Ubuntu, krb5-workstation on RHEL/Fedora; pre-installed on macOS)"
+    fi
+fi
+
 DEFAULT_KRB5_CONFIG="$HOME/.config/krb5.conf"
 
 if [[ -n "${KRB5_CONFIG:-}" ]]; then
@@ -30,6 +58,10 @@ if [[ -n "${KRB5_CONFIG:-}" ]]; then
     if [[ ! -f "$KRB5_CONFIG" ]]; then
         _bail "KRB5_CONFIG is set to '$KRB5_CONFIG' but the file does not exist"
     fi
+    # Re-export in native form (no-op outside Windows; idempotent if
+    # the user already set a Windows-style path)
+    KRB5_CONFIG="$(_native_path "$KRB5_CONFIG")"
+    export KRB5_CONFIG
 else
     # Variable is not set — use default path, creating config if needed
     if [[ ! -f "$DEFAULT_KRB5_CONFIG" ]]; then
@@ -57,7 +89,8 @@ else
     cern.ch = CERN.CH
 CONF
     fi
-    export KRB5_CONFIG="$DEFAULT_KRB5_CONFIG"
+    KRB5_CONFIG="$(_native_path "$DEFAULT_KRB5_CONFIG")"
+    export KRB5_CONFIG
 fi
 
 kinit "${USERNAME}@CERN.CH"

--- a/ssh/keys/setup_lxplus_key.sh
+++ b/ssh/keys/setup_lxplus_key.sh
@@ -44,11 +44,20 @@ _native_path() {
 }
 
 if ! command -v kinit &>/dev/null; then
-    if [[ "$IS_WINDOWS" == true ]]; then
-        _bail "kinit not found. Install MIT Kerberos for Windows (https://web.mit.edu/kerberos/dist/), then open a new terminal so kinit.exe is on PATH"
-    else
-        _bail "kinit not found. Install a Kerberos client (krb5-user on Debian/Ubuntu, krb5-workstation on RHEL/Fedora; pre-installed on macOS)"
-    fi
+    case "$(uname -s)" in
+        MINGW*|MSYS*|CYGWIN*)
+            _bail "kinit not found. Install MIT Kerberos for Windows (https://web.mit.edu/kerberos/dist/) and open a new terminal so kinit.exe is on PATH"
+            ;;
+        Darwin)
+            _bail "kinit not found. macOS ships kinit at /usr/bin/kinit — check that /usr/bin is on your PATH"
+            ;;
+        Linux)
+            _bail "kinit not found. Install a Kerberos client: krb5-user (Debian/Ubuntu) or krb5-workstation (RHEL/Fedora)"
+            ;;
+        *)
+            _bail "kinit not found. Install a Kerberos client for your platform"
+            ;;
+    esac
 fi
 
 DEFAULT_KRB5_CONFIG="$HOME/.config/krb5.conf"

--- a/ssh/keys/setup_nersc_key.sh
+++ b/ssh/keys/setup_nersc_key.sh
@@ -45,14 +45,32 @@ case "$OS" in
         FILE_EXT="tar.gz"
         SSHPROXY_BIN="$BIN_DIR/sshproxy"
         ;;
+    MINGW*|MSYS*|CYGWIN*)
+        # Git Bash / MSYS2 / Cygwin. NERSC ships a single MSIX bundle
+        # for Windows; installing it exposes an app-execution alias
+        # 'sshproxy' under %LOCALAPPDATA%\Microsoft\WindowsApps, which
+        # is on PATH — so the binary is resolved by name, not by path.
+        OS_PATTERN="windows-universal"
+        FILE_EXT="msixbundle"
+        SSHPROXY_BIN="sshproxy"
+        ;;
     *)
         echo "Error: unsupported OS: $OS"
         exit 1
         ;;
 esac
 
+# Is sshproxy already installed? On Windows it lives on PATH; elsewhere
+# at a fixed location.
+_sshproxy_installed() {
+    case "$OS" in
+        MINGW*|MSYS*|CYGWIN*) command -v sshproxy &>/dev/null ;;
+        *)                    [[ -x "$SSHPROXY_BIN" ]] ;;
+    esac
+}
+
 # Download and install sshproxy only if not already present
-if [[ ! -x "$SSHPROXY_BIN" ]]; then
+if ! _sshproxy_installed; then
     echo "==> Detecting latest sshproxy version for $OS_PATTERN from $NERSC_PORTAL"
     VERSION=$(curl -s "$NERSC_PORTAL/" \
         | grep -oE "sshproxy-[0-9]+\.[0-9]+\.[0-9]+-${OS_PATTERN}\.${FILE_EXT}" \
@@ -88,6 +106,20 @@ if [[ ! -x "$SSHPROXY_BIN" ]]; then
                     -exec mv {} "$BIN_DIR/sshproxy" \;
             fi
             chmod +x "$SSHPROXY_BIN"
+            ;;
+        MINGW*|MSYS*|CYGWIN*)
+            echo "==> Installing MSIX package (per-user, no admin required)"
+            # Native PowerShell needs a Windows-style path, and MSYS
+            # does not auto-convert paths embedded in -Command strings.
+            WIN_PATH="$(cygpath -w "$DOWNLOAD_PATH")"
+            powershell.exe -NoProfile -Command "Add-AppxPackage -Path '$WIN_PATH'"
+            rm "$DOWNLOAD_PATH"
+            if ! command -v sshproxy &>/dev/null; then
+                echo "Error: sshproxy installed but not found on PATH."
+                echo "       Make sure %LOCALAPPDATA%\\Microsoft\\WindowsApps is in your"
+                echo "       Windows PATH, then open a new terminal and re-run."
+                exit 1
+            fi
             ;;
     esac
     echo "==> sshproxy installed at $SSHPROXY_BIN"

--- a/ssh/keys/setup_ssh_key.sh
+++ b/ssh/keys/setup_ssh_key.sh
@@ -72,16 +72,18 @@ if [[ "$NEEDS_USER" == true && -z "$USERNAME" ]]; then
     exit 1
 fi
 
-# Locate the per-host script
+# Locate the per-host script. Test -f rather than -x and invoke via
+# bash: the executable bit is unreliable on Windows filesystems (Git
+# Bash / NTFS), and running through bash works identically everywhere.
 HOST_SCRIPT="$SCRIPT_DIR/setup_${HOST}_key.sh"
-if [[ ! -x "$HOST_SCRIPT" ]]; then
-    echo "Error: script not found or not executable: $HOST_SCRIPT"
+if [[ ! -f "$HOST_SCRIPT" ]]; then
+    echo "Error: script not found: $HOST_SCRIPT"
     exit 1
 fi
 
 # Delegate to the per-host script
 if [[ "$NEEDS_USER" == true ]]; then
-    "$HOST_SCRIPT" -u "$USERNAME"
+    bash "$HOST_SCRIPT" -u "$USERNAME"
 else
-    "$HOST_SCRIPT"
+    bash "$HOST_SCRIPT"
 fi


### PR DESCRIPTION
## What's failing

| Symptom (Git Bash on Windows 11) | Affected script |
|---|---|
| `Error: unsupported OS: MINGW64_NT-10.0-26100` | `setup_nersc_key.sh` |
| `setup_lxplus_key.sh: line 60: kinit: command not found` (no client installed) | `setup_lxplus_key.sh` |
| Native MIT `kinit.exe` cannot open KRB5_CONFIG=/c/Users/foo/.config/krb5.conf | `setup_lxplus_key.sh` |
| `Permission denied` or `script not found or not executable` after fresh clone | `setup_ssh_key.sh`, `setup_lrc_key.sh` |

WSL was never affected — `uname -s` reports `Linux` there, and the existing branches handle it.

## Root cause

Three independent gaps in the Windows path:

1. **NERSC** — the `uname -s` case in `setup_nersc_key.sh` only knew `Darwin` and `Linux`, despite NERSC publishing a `windows-universal` MSIX package at `https://portal.nersc.gov/cfs/mfa/`.
2. **lxplus** — no `kinit` precheck (Git Bash doesn't bundle one), and `KRB5_CONFIG` was exported as an MSYS-style path. Native Windows `kinit.exe` can't open `/c/Users/...`; MSYS converts command-line arguments but not arbitrary environment variables. The MIT Kerberos docs are explicit that `KRB5_CONFIG` must be a fully qualified path the native binary can read.
3. **Dispatcher / LRC** — both relied on the POSIX executable bit, which NTFS does not reliably preserve through `git clone` or zip extraction under Git Bash. `setup.sh`'s aliases already invoke scripts via `bash <path>` for exactly this reason; the per-host invocations had drifted.

## The fix

### exec-bit independence (commit 1)

```bash
HOST_SCRIPT="$SCRIPT_DIR/setup_${HOST}_key.sh"
if [[ ! -f "$HOST_SCRIPT" ]]; then
    echo "Error: script not found: $HOST_SCRIPT"
    exit 1
fi

if [[ "$NEEDS_USER" == true ]]; then
    bash "$HOST_SCRIPT" -u "$USERNAME"
else
    bash "$HOST_SCRIPT"
fi
```

Same change in `setup_lrc_key.sh` — drop the `chmod +x` and run `bash "$REQUEST_CERT" -p lrc`.

### lxplus native KRB5_CONFIG (commit 2)

```bash
case "$(uname -s)" in
    MINGW*|MSYS*|CYGWIN*) IS_WINDOWS=true ;;
    *)                    IS_WINDOWS=false ;;
esac

_native_path() {
    if [[ "$IS_WINDOWS" == true ]] && command -v cygpath &>/dev/null; then
        cygpath -w "$1"
    else
        printf '%s' "$1"
    fi
}

if ! command -v kinit &>/dev/null; then
    if [[ "$IS_WINDOWS" == true ]]; then
        _bail "kinit not found. Install MIT Kerberos for Windows (https://web.mit.edu/kerberos/dist/), then open a new terminal so kinit.exe is on PATH"
    else
        _bail "kinit not found. Install a Kerberos client (krb5-user on Debian/Ubuntu, krb5-workstation on RHEL/Fedora; pre-installed on macOS)"
    fi
fi
```

`KRB5_CONFIG` is routed through `_native_path` on both the user-set and default branches. The helper is a no-op outside Windows and idempotent on already-Windows paths.

### NERSC msixbundle (commit 3)

```bash
MINGW*|MSYS*|CYGWIN*)
    OS_PATTERN="windows-universal"
    FILE_EXT="msixbundle"
    SSHPROXY_BIN="sshproxy"
    ;;
```

and in the install switch:

```bash
MINGW*|MSYS*|CYGWIN*)
    echo "==> Installing MSIX package (per-user, no admin required)"
    WIN_PATH="$(cygpath -w "$DOWNLOAD_PATH")"
    powershell.exe -NoProfile -Command "Add-AppxPackage -Path '$WIN_PATH'"
    rm "$DOWNLOAD_PATH"
    if ! command -v sshproxy &>/dev/null; then
        echo "Error: sshproxy installed but not found on PATH."
        echo "       Make sure %LOCALAPPDATA%\\Microsoft\\WindowsApps is in your"
        echo "       Windows PATH, then open a new terminal and re-run."
        exit 1
    fi
    ;;
```

Presence is checked via `command -v sshproxy` rather than `-x` against a fixed path, because MSIX surfaces the binary through an app-execution alias on `PATH`, not at a known location.