### PR TITLE
[feat] ssh-remote-auth: auto-resolve username from SSH config

### DIFF
--- a/ssh/keys/setup_ssh_key.sh
+++ b/ssh/keys/setup_ssh_key.sh
@@ -22,9 +22,39 @@ usage() {
     echo
     echo "Supported hosts: $SUPPORTED_HOSTS"
     echo
-    echo "Hosts requiring a username (-u): lxplus, nersc, s3df"
-    echo "Hosts with username handled internally: lrc"
+    echo "If -u is omitted for a host that takes a username, it is auto-resolved"
+    echo "from your SSH config via 'ssh -G <host>'. Run 'ssh-remote-config'"
+    echo "first to install one. Pass -u explicitly to override."
+    echo
+    echo "Hosts that do not take a username: lrc (handled internally)"
     exit 1
+}
+
+# Resolve the User directive for a host alias by asking ssh itself.
+# 'ssh -G' merges ~/.ssh/config and any files brought in via Include,
+# applies Host pattern matches, and prints the effective config as
+# lowercase key/value lines.
+#
+# Caveat: if no Host stanza matches, ssh -G still emits a `user`
+# line — it falls back to the local username. Detect that case by
+# probing a deliberately non-existent host alias and comparing; if
+# the real host resolves to the same value, there's no host-specific
+# config and we should fail with a helpful message rather than try
+# kinit local-user@CERN.CH and confuse the user with a Kerberos
+# "client not found" error.
+_resolve_ssh_user() {
+    local host="$1"
+    command -v ssh &>/dev/null || return 1
+
+    local resolved fallback
+    resolved=$(ssh -G "$host" 2>/dev/null | awk '/^user /{print $2; exit}')
+    fallback=$(ssh -G "_ssh_remote_auth_probe_$$" 2>/dev/null | awk '/^user /{print $2; exit}')
+
+    if [[ -n "$resolved" && "$resolved" != "$fallback" ]]; then
+        printf '%s' "$resolved"
+        return 0
+    fi
+    return 1
 }
 
 HOST=""
@@ -68,8 +98,14 @@ if [[ "$NEEDS_USER" == "UNDEFINED" ]]; then
 fi
 
 if [[ "$NEEDS_USER" == true && -z "$USERNAME" ]]; then
-    echo "Error: host '$HOST' requires a username (-u <username>)"
-    exit 1
+    if USERNAME="$(_resolve_ssh_user "$HOST")"; then
+        echo "==> Using username '$USERNAME' (from SSH config)"
+    else
+        echo "Error: no username configured for host '$HOST' in your SSH config." >&2
+        echo "       Set one up: ssh-remote-config --$HOST <username>" >&2
+        echo "       Or pass it: ssh-remote-auth --host $HOST -u <username>" >&2
+        exit 1
+    fi
 fi
 
 # Locate the per-host script. Test -f rather than -x and invoke via

--- a/ssh/keys/status_ssh_keys.sh
+++ b/ssh/keys/status_ssh_keys.sh
@@ -50,7 +50,7 @@ if command -v klist &>/dev/null; then
             _ok "Valid ticket — expires $EXPIRY_FMT ($REMAINING remaining)"
         else
             EXPIRY_FMT=$(_fmt_date "$EXPIRY_EPOCH")
-            _err "Ticket expired ($EXPIRY_FMT) — run: ssh-remote-auth --host lxplus -u <username>"
+            _err "Ticket expired ($EXPIRY_FMT) — run: ssh-remote-auth --host lxplus"
         fi
 
         # $(NF-1) gets the flags field regardless of date format variations across OSes
@@ -60,10 +60,10 @@ if command -v klist &>/dev/null; then
         else
             _warn "Ticket is not forwardable — SSH login works but Kerberos"
             _warn "credentials won't be delegated (AFS/EOS on lxplus may be inaccessible)."
-            _warn "Check 'forwardable = true' is in your krb5.conf, then re-run: ssh-remote-auth --host lxplus -u <username>"
+            _warn "Check 'forwardable = true' is in your krb5.conf, then re-run: ssh-remote-auth --host lxplus"
         fi
     else
-        _err "No valid Kerberos ticket — run: ssh-remote-auth --host lxplus -u <username>"
+        _err "No valid Kerberos ticket — run: ssh-remote-auth --host lxplus"
     fi
 else
     _warn "klist not found — Kerberos tools may not be installed"
@@ -83,10 +83,10 @@ if [[ -f "$NERSC_CERT" ]]; then
         _ok "Valid certificate — expires $EXPIRY_FMT ($REMAINING remaining)"
     else
         EXPIRY_FMT=$(_fmt_date "$EXPIRY_EPOCH")
-        _err "Certificate expired ($EXPIRY_FMT) — run: ssh-remote-auth --host nersc -u <username>"
+        _err "Certificate expired ($EXPIRY_FMT) — run: ssh-remote-auth --host nersc"
     fi
 else
-    _err "No certificate found at $NERSC_CERT — run: ssh-remote-auth --host nersc -u <username>"
+    _err "No certificate found at $NERSC_CERT — run: ssh-remote-auth --host nersc"
 fi
 
 # ── LRC / Lawrencium (SSH certificate) ───────────────────────
@@ -121,7 +121,7 @@ if [[ -f "$S3DF_KEY" ]]; then
     _ok "Key present — created $CREATED"
     _warn "S3DF keys expire periodically — re-register at https://s3df-sshkeys.slac.stanford.edu if login fails"
 else
-    _err "No key found at $S3DF_KEY — run: ssh-remote-auth --host s3df -u <username>"
+    _err "No key found at $S3DF_KEY — run: ssh-remote-auth --host s3df"
 fi
 
 echo


### PR DESCRIPTION
## What this changes

Before:

```
$ ssh-remote-auth --host lxplus
Error: host 'lxplus' requires a username (-u <username>)

$ ssh-remote-auth --host lxplus -u alice    # the username I already
                                            # told ssh-remote-config
```

After:

```
$ ssh-remote-auth --host lxplus
==> Using username 'alice' (from SSH config)
...
```

`-u` still works and overrides the lookup — useful for secondary
accounts at the same facility — but the common case where you have
exactly one username per host stops requiring it.

## How

`ssh -G <host>` reads `~/.ssh/config`, follows `Include` directives,
applies `Host` pattern matches, and prints the effective config as
lowercase key/value lines. Available on every platform we target
(Linux, macOS, WSL, Git Bash) since OpenSSH 6.8 / 2015. The
dispatcher pulls out the `user` line:

```bash
_resolve_ssh_user() {
    local host="$1"
    command -v ssh &>/dev/null || return 1

    local resolved fallback
    resolved=$(ssh -G "$host" 2>/dev/null | awk '/^user /{print $2; exit}')
    fallback=$(ssh -G "_ssh_remote_auth_probe_$$" 2>/dev/null | awk '/^user /{print $2; exit}')

    if [[ -n "$resolved" && "$resolved" != "$fallback" ]]; then
        printf '%s' "$resolved"
        return 0
    fi
    return 1
}
```

## The fallback-detection probe

`ssh -G` emits a `user` line **even when no `Host` stanza matches**
— it falls back to the local `$USER`. Naively trusting `ssh -G` would
silently try `kinit root@CERN.CH` for unconfigured hosts, producing
a confusing Kerberos error several lines downstream.

Probing a deliberately non-existent host (`_ssh_remote_auth_probe_$$`,
with `$$` for collision safety) tells us what the "no config" value
looks like. If the real host resolves to the same value, no
host-specific config exists and we should fail loudly with a pointer
to `ssh-remote-config`.

This is robust against `Host *` globals — both real and probe inherit
the same global default, but a host-specific `User alice` only
applies to the real host, so the values differ exactly when there's
a host-specific override (the case we want to use).