### PR TITLE
[feat] ssh auth LRC: auto-fill username into request_cert.sh interactive prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,10 @@ If no host-specific `User` is set in your SSH config and `-u` is
 omitted, the dispatcher errors out and points you at the right
 fix rather than silently trying `kinit $USER@CERN.CH`.
 
+For **lrc** specifically: the resolved username is also pre-filled
+into the upstream `request_cert.sh` interactive prompt, so only PIN
+and OTP need to be typed.
+
 ### Adding a New Host
 
 **1. Register in `ssh/keys/setup_ssh_key.sh`:**

--- a/ssh/keys/setup_lrc_key.sh
+++ b/ssh/keys/setup_lrc_key.sh
@@ -5,8 +5,18 @@ LRC_SCRIPTS_REPO="https://github.com/lbnl-science-it/lrc-scripts.git"
 LRC_SCRIPTS_DIR="$HOME/.ssh/lrc-scripts"
 REQUEST_CERT="$LRC_SCRIPTS_DIR/request_cert.sh"
 
+usage() { echo "Usage: $0 -u <username>" >&2; exit 1; }
+
+USERNAME=""
+while getopts "u:h" opt; do
+    case "$opt" in
+        u) USERNAME="$OPTARG" ;;
+        *) usage ;;
+    esac
+done
+[[ -z "$USERNAME" ]] && { echo "Error: -u <username> is required" >&2; usage; }
+
 if [[ -d "$LRC_SCRIPTS_DIR" ]]; then
-    # Directory exists — check it's a valid git repo before pulling
     if [[ -d "$LRC_SCRIPTS_DIR/.git" ]]; then
         echo "==> Updating lrc-scripts"
         git -C "$LRC_SCRIPTS_DIR" pull --ff-only
@@ -20,12 +30,55 @@ else
     git clone "$LRC_SCRIPTS_REPO" "$LRC_SCRIPTS_DIR"
 fi
 
-# Run through bash rather than relying on the exec bit — chmod +x is
-# not reliably honored on Windows filesystems (Git Bash / NTFS).
 if [[ ! -f "$REQUEST_CERT" ]]; then
     echo "Error: request_cert.sh not found in $LRC_SCRIPTS_DIR after clone/pull"
     echo "       The repository structure may have changed — check $LRC_SCRIPTS_REPO"
     exit 1
 fi
 
-bash "$REQUEST_CERT" -p lrc
+# Always print the username so the user can see it whether auto-fill
+# fires or not.
+cat <<BANNER
+
+============================================================
+  LRC username: $USERNAME
+  PIN and OTP will be prompted next (enter manually)
+============================================================
+
+BANNER
+
+# Source-patch the upstream username prompt so it's pre-filled.
+#
+# Why patch instead of pipe: gen_cert() reads username, PIN, and OTP
+# all from plain stdin via 'read -r'. Piping just the username would
+# leave the next two reads with EOF — empty PIN/OTP → 401 from the
+# server. Patching out the username read entirely lets PIN/OTP reads
+# proceed normally from the terminal.
+#
+# Defensive: only patch if the exact upstream pattern is present;
+# otherwise run the script unmodified and rely on the banner above.
+# If LBNL ever changes the prompt format (e.g. printf instead of
+# 'echo -n'), our grep misses and we degrade gracefully — the user
+# just types the username from the banner.
+PATTERN_ECHO='echo -n "Username: "'
+PATTERN_READ='read -r user'
+
+if grep -qF "$PATTERN_ECHO" "$REQUEST_CERT" && grep -qF "$PATTERN_READ" "$REQUEST_CERT"; then
+    PATCHED=$(mktemp -t lrc_request_cert.XXXXXX.sh)
+    trap 'rm -f "$PATCHED"' EXIT
+
+    # The username travels through an env var rather than being
+    # interpolated into the sed expression — sidesteps any escaping
+    # concern even if the username happens to contain a sed
+    # metacharacter (|, &, \, etc).
+    sed \
+        -e 's|echo -n "Username: "|echo "Username (auto-filled): ${LRC_USERNAME}"|' \
+        -e 's|read -r user|user="${LRC_USERNAME}"|' \
+        "$REQUEST_CERT" > "$PATCHED"
+
+    LRC_USERNAME="$USERNAME" bash "$PATCHED" -p lrc
+else
+    echo "==> Note: upstream prompt format has changed; auto-fill skipped."
+    echo "    Type the username shown above when prompted."
+    bash "$REQUEST_CERT" -p lrc
+fi

--- a/ssh/keys/setup_ssh_key.sh
+++ b/ssh/keys/setup_ssh_key.sh
@@ -10,7 +10,7 @@ SUPPORTED_HOSTS="lxplus nersc s3df lrc"
 NEEDS_USER_lxplus=true
 NEEDS_USER_nersc=true
 NEEDS_USER_s3df=true
-NEEDS_USER_lrc=false
+NEEDS_USER_lrc=true
 
 # ============================================================
 # Core logic
@@ -25,8 +25,6 @@ usage() {
     echo "If -u is omitted for a host that takes a username, it is auto-resolved"
     echo "from your SSH config via 'ssh -G <host>'. Run 'ssh-remote-config'"
     echo "first to install one. Pass -u explicitly to override."
-    echo
-    echo "Hosts that do not take a username: lrc (handled internally)"
     exit 1
 }
 


### PR DESCRIPTION
## What this changes

Before:

```
$ ssh-remote-auth --host lrc
==> Cloning lrc-scripts to ~/.ssh/lrc-scripts
Username: alice            ← user has to remember & type
PIN: ******
OTP: 123456
```

After:

```
$ ssh-remote-auth --host lrc
==> Updating lrc-scripts

============================================================
  LRC username: alice
  PIN and OTP will be prompted next (enter manually)
============================================================

Username (auto-filled): alice
PIN: ******
OTP: 123456
```

`-u` still works as an explicit override for secondary accounts.

## Why not just pipe the username

The naive `printf "alice\n" | request_cert.sh -p lrc` doesn't work.
`gen_cert()` in the upstream script reads three things in order
without redirecting from /dev/tty:

```bash
echo -n "Username: "; read -r user
echo -n "PIN: ";       read -rs password
echo -ne "\n"
echo -n "OTP: ";       read -r mfa
```

Piping a single line leaves the PIN and OTP reads with EOF — empty
strings in the request body → 401 from the server. Piping all three
defeats the point (the OTP regenerates every 30 s; you can't script
it). `expect` would work but adds a dependency that isn't on Git Bash
by default, undoing the Windows-support PR.

So instead: source-patch the username read out of the script
entirely. PIN and OTP reads happen normally from the terminal.

## How the patch works

```bash
PATTERN_ECHO='echo -n "Username: "'
PATTERN_READ='read -r user'

if grep -qF "$PATTERN_ECHO" "$REQUEST_CERT" && grep -qF "$PATTERN_READ" "$REQUEST_CERT"; then
    PATCHED=$(mktemp -t lrc_request_cert.XXXXXX.sh)
    trap 'rm -f "$PATCHED"' EXIT
    sed \
        -e 's|echo -n "Username: "|echo "Username (auto-filled): ${LRC_USERNAME}"|' \
        -e 's|read -r user|user="${LRC_USERNAME}"|' \
        "$REQUEST_CERT" > "$PATCHED"
    LRC_USERNAME="$USERNAME" bash "$PATCHED" -p lrc
else
    echo "==> Note: upstream prompt format has changed; auto-fill skipped."
    bash "$REQUEST_CERT" -p lrc
fi
```

The username travels via an env var (`LRC_USERNAME`) rather than being
embedded in the sed replacement — sidesteps any escaping issues
should a username ever contain a sed metacharacter (`|`, `&`, `\`).

## Defensive fallback

The grep guards on both literal patterns. If LBNL ever changes the
prompt format — say `echo -n` becomes `printf`, or someone reformats
to a single line — both `grep -qF` checks miss, the patch step is
skipped, and the original script runs unmodified. The banner above
ensures the user still sees the resolved username and can type it.
This isn't theoretical: the script is upstream and out of our control;
the entire defensive path exists to keep us from silently producing
a broken patched script the day someone reformats it.