### PR TITLE
[feat] Conda env: Miniforge base, GPU-aware DL, acceptance test

### DIFF
--- a/environment/create_conda_environment.sh
+++ b/environment/create_conda_environment.sh
@@ -1,291 +1,546 @@
 #!/bin/bash
+#
+# create_conda_environment.sh
+#
+# Bootstrap a Miniforge (conda-forge) base and build a scientific Python
+# environment from it. Everything is installed from conda-forge with strict
+# channel priority; GPU-heavy deep-learning frameworks are handled so that a
+# single environment ends up with exactly one, consistent CUDA stack.
+#
+# Supported platforms: Linux and macOS (Intel/Apple Silicon). WSL works as
+# Linux. Native Windows (Git Bash/MSYS) is not supported -- run under WSL.
+#
+# Resolution strategy (order matters for a clean solve):
+#   1. ROOT first          -- heaviest constraints, pins a compatible base
+#   2. one combined solve  -- base sci stack + requested conda package groups
+#   3. conda PyTorch        -- only when PyTorch is the *sole* DL framework
+#   4. pip last             -- multi-framework DL group + pip-only extras
+#
+# CUDA policy:
+#   * PyTorch alone            -> conda-forge pytorch-gpu / pytorch-cpu
+#                                 (auto-selected via the NVIDIA driver).
+#   * PyTorch + TF and/or JAX  -> all frameworks via pip, installed last and
+#     (or TF/JAX without torch)   together so they share one nvidia-*-cu12 set.
+#   The two modes never mix, so there is only ever a single CUDA provider.
 
-# Function to create or ensure Miniconda installation
-create_conda () {
+set -o pipefail
 
-    # Check if conda is already installed
-    if [[ -f "${CONDADIR}/miniconda/etc/profile.d/conda.sh" ]]; then
-        echo "INFO: conda already installed."
-        return 0
-    fi
-
-    # Create CONDADIR if it doesn't exist
-    if [[ ! -d "$CONDADIR" ]]; then
-        mkdir -p "$CONDADIR"
-    fi
-
-    # Determine the correct Miniconda installer file based on OS and architecture
-    if [[ "$OSTYPE" == "linux"* ]]; then
-        # Linux
-        CONDABASHFILE="Miniconda3-latest-Linux-x86_64.sh"
-    elif [[ "$OSTYPE" == "darwin"* ]]; then
-        # MacOS
-        if [[ "$(uname -m)" == "arm"* ]]; then
-            CONDABASHFILE="Miniconda3-latest-MacOSX-arm64.sh"
-        else
-            CONDABASHFILE="Miniconda3-latest-MacOSX-x86_64.sh"
-        fi
-    else
-        echo "ERROR: unsupported operating system: $OSTYPE"
-        return 1
-    fi
-
-    # --- Download Utility Selection Logic ---
-    local download_cmd=""
-    local download_option_out="" # Option for output file (-O for wget, -o for curl)
-
-    # Check for wget
-    if command -v wget >/dev/null 2>&1; then
-        download_cmd="wget"
-        download_option_out="-P" # wget uses -P for directory
-        echo "INFO: Using wget for download."
-    # Check for curl if wget is not found
-    elif command -v curl >/dev/null 2>&1; then
-        download_cmd="curl"
-        download_option_out="-o" # curl uses -o for output file name, needs full path
-        echo "INFO: Using curl for download."
-    else
-        echo "ERROR: Neither wget nor curl is installed. Please install one of them and rerun the script."
-        return 1
-    fi
-
-    # Construct the full download URL
-    local download_url="https://repo.anaconda.com/miniconda/${CONDABASHFILE}"
-    local local_installer_path="${CONDADIR}/${CONDABASHFILE}"
-
-    # Only download the shell script if it doesn't exist
-    if [[ ! -f "${local_installer_path}" ]]; then
-        echo "INFO: Downloading Miniconda installer: ${CONDABASHFILE}..."
-        if [[ "$download_cmd" == "wget" ]]; then
-            # wget -P <directory> <URL>
-            "$download_cmd" "${download_option_out}" "${CONDADIR}" "${download_url}"
-        elif [[ "$download_cmd" == "curl" ]]; then
-            # curl -o <output_file_path> <URL>
-            "$download_cmd" "${download_option_out}" "${local_installer_path}" "${download_url}"
-        fi
-
-        # Check if the download was successful
-        if [ $? -ne 0 ]; then
-            echo "ERROR: Failed to download Miniconda installer using $download_cmd."
-            return 1
-        fi
-    else
-        echo "INFO: Miniconda installer already exists: ${CONDABASHFILE}. Skipping download."
-    fi
-
-    # Run the Miniconda installer
-    echo "INFO: Installing Miniconda to ${CONDADIR}/miniconda..."
-    bash "${local_installer_path}" -b -p "${CONDADIR}/miniconda"
-    if [ $? -ne 0 ]; then
-        echo "ERROR: Miniconda installation failed."
-        return 1
-    fi
-}
-
-# Function to configure conda settings
-configure_conda() {
-    echo "INFO: Configuring conda..."
-    conda config --set channel_priority strict
-    conda config --set solver libmamba
-}
-
+# --------------------------------------------------------------------------- #
+# Defaults
+# --------------------------------------------------------------------------- #
 CONDA_ENV_NAME="envbase"
 CONDA_PYTHON_VERSION="3.12"
+ROOT_INSTALL_VERSION="latest"
+CUDA_OVERRIDE="auto"           # auto | 12 | 13 | cpu
+
+CONDADIR=""
 CONDADIR_SET=false
+
 INSTALL_ROOT=false
 INSTALL_HEP=false
 INSTALL_MLBASE=false
 INSTALL_ALKAID=false
+INSTALL_PYTORCH=false
 INSTALL_TENSORFLOW=false
+INSTALL_JAX=false
+INSTALL_TRANSFER=false
+INSTALL_ATLAS=false
 INSTALL_WORKFLOW=false
-ROOT_INSTALL_VERSION="latest"
 
-usage() {
-    echo "Usage: $0 [-d|--dir VALUE] [-n|--name VALUE] [-p|--python VALUE] [-r|--root] [-m|--mlbase] [--rootver VALUE] [--alkaid] [--tensorflow]"
-    echo "  -d, --dir       : Directory to install conda (REQUIRED)"
-    echo "  -n, --name      : Name of conda environment (default: $CONDA_ENV_NAME)"
-    echo "  -p, --python    : Python version for the environment (default: $CONDA_PYTHON_VERSION)"
-    echo "  -r, --root      : (flag) Install ROOT data analysis framework"
-    echo "  --rootver       : Version of ROOT to install (default: $ROOT_INSTALL_VERSION, only with -r)"
-    echo "  -h, --hep       : (flag) Install high energy physics libraries"
-    echo "  -w, --workflow  : (flag) Install workflow libraries"
-    echo "  -m, --mlbase    : (flag) Install basic Machine Learning packages"
-    echo "  --tensorflow    : (flag) Install TensorFlow (with CUDA support if available)"
-    echo "  --alkaid        : (flag) Install Alkaid's specific packages"
-    return 1
+MINIFORGE_URL_BASE="https://github.com/conda-forge/miniforge/releases/latest/download"
+
+# PyTorch pip wheel index tags per CUDA major, newest-first. Probed against the
+# live index before use, so a retired tag degrades gracefully. Bump as PyTorch
+# publishes new builds.
+TORCH_CU12_TAGS=(cu129 cu128 cu126)
+TORCH_CU13_TAGS=(cu130)
+
+# MadGraph5_aMC@NLO is installed from the official tarball (not conda) so it does
+# not pin the environment's Python; current releases support Python 3.12+.
+# Override the version with --mg5ver.
+MG5_VERSION="3.7.2"
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+die()  { echo "ERROR: $*" >&2; exit 1; }
+info() { echo "INFO: $*"; }
+warn() { echo "WARNING: $*" >&2; }
+
+# Echo a command, run it, and abort with a clear message on failure.
+run() {
+    echo "+ $*"
+    "$@" || die "command failed: $*"
 }
 
-main() {
+usage() {
+    cat <<EOF
+Usage: $0 -d DIR [options]
 
-    export CONDA_PLUGINS_AUTO_ACCEPT_TOS=true
-    
-    # Parse arguments
+Bootstrap Miniforge and build a conda-forge scientific Python environment.
+
+Required:
+  -d, --dir DIR       Directory to install Miniforge and its environments
+
+Environment:
+  -n, --name NAME     Conda environment name (default: $CONDA_ENV_NAME)
+  -p, --python VER    Python version (default: $CONDA_PYTHON_VERSION)
+
+Package groups (opt-in):
+  -r, --root          ROOT + HEP python ecosystem (uproot, awkward, vector, hist, mplhep)
+      --rootver VER   ROOT version (default: $ROOT_INSTALL_VERSION; only with -r)
+      --hep           HEP generators (delphes, pythia8, fastjet; madgraph from source)
+      --mg5ver VER    MadGraph version to install (default: $MG5_VERSION; only with --hep)
+  -m, --mlbase        Classical ML stack (scikit-learn, xgboost, ray, ...)
+      --transfer      File-transfer tools (rclone, globus-cli, openssh)
+      --atlas         ATLAS grid tools (rucio-clients, gfal2 family)
+  -w, --workflow      Workflow tools (law)
+      --alkaid        Alkaid's personal packages
+
+Deep-learning frameworks (GPU-aware):
+      --pytorch       PyTorch
+      --tensorflow    TensorFlow
+      --jax           JAX
+      --dl            Shortcut for --pytorch --tensorflow --jax (coexisting)
+
+GPU / CUDA:
+      --cuda VALUE    Force the CUDA target for the pip DL path: 12 | 13 | cpu
+                      (default: auto-detect from the NVIDIA driver)
+
+Other:
+  -h, --help          Show this help and exit
+EOF
+}
+
+# Guard the platform. WSL reports as Linux and is fine; only native Windows
+# (Git Bash / MSYS / Cygwin) needs to be rejected with an actionable message.
+detect_platform() {
+    case "$OSTYPE" in
+        linux*|darwin*) return 0 ;;
+        msys*|cygwin*)
+            die "Native Windows (Git Bash/MSYS) is not supported. Run this inside WSL, where it works unchanged as Linux." ;;
+    esac
+    case "$(uname -s)" in
+        Linux|Darwin) return 0 ;;
+        MINGW*|MSYS*|CYGWIN*)
+            die "Native Windows (Git Bash/MSYS) is not supported. Run this inside WSL, where it works unchanged as Linux." ;;
+        *) die "Unsupported operating system: $OSTYPE / $(uname -s)" ;;
+    esac
+}
+
+# Download URL -> destination, preferring curl then wget.
+download() {
+    local url="$1" dest="$2"
+    if command -v curl >/dev/null 2>&1; then
+        curl -fL -o "$dest" "$url"
+    elif command -v wget >/dev/null 2>&1; then
+        wget -O "$dest" "$url"
+    else
+        die "Neither curl nor wget is installed; cannot download $url"
+    fi
+}
+
+# Ensure a Miniforge base exists at $1 (idempotent).
+install_miniforge() {
+    local prefix="$1"
+
+    if [[ -f "${prefix}/etc/profile.d/conda.sh" ]]; then
+        info "conda already installed at ${prefix}"
+        return 0
+    fi
+
+    mkdir -p "$CONDADIR" || die "cannot create ${CONDADIR}"
+
+    local asset="Miniforge3-$(uname)-$(uname -m).sh"
+    local url="${MINIFORGE_URL_BASE}/${asset}"
+    local installer="${CONDADIR}/${asset}"
+
+    if [[ ! -f "$installer" ]]; then
+        info "Downloading Miniforge installer: ${asset}"
+        download "$url" "$installer" || die "failed to download ${url}"
+    else
+        info "Miniforge installer already present: ${asset}"
+    fi
+
+    info "Installing Miniforge to ${prefix}"
+    bash "$installer" -b -p "$prefix" || die "Miniforge installation failed"
+}
+
+configure_conda() {
+    info "Configuring conda (strict channel priority, libmamba solver)"
+    conda config --set channel_priority strict
+    conda config --set solver libmamba
+}
+
+# --------------------------------------------------------------------------- #
+# GPU / CUDA detection
+# --------------------------------------------------------------------------- #
+
+# True if a usable NVIDIA GPU + driver is present.
+has_nvidia_gpu() {
+    command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi -L >/dev/null 2>&1
+}
+
+# Echo the driver's maximum supported CUDA *major* (e.g. "12"), or nothing.
+# This is the ceiling the driver can run -- not an installed toolkit.
+driver_cuda_major() {
+    has_nvidia_gpu || return 0
+    nvidia-smi 2>/dev/null \
+        | sed -n 's/.*CUDA Version:[[:space:]]*\([0-9][0-9]*\)\.[0-9].*/\1/p' \
+        | head -1
+}
+
+# Echo a PyTorch pip index tag (e.g. "cu129") for a CUDA major, probing the
+# live index so retired tags are skipped. Empty if none is available.
+torch_index_tag() {
+    local major="$1"
+    local -a cands=()
+    case "$major" in
+        12) cands=("${TORCH_CU12_TAGS[@]}") ;;
+        13) cands=("${TORCH_CU13_TAGS[@]}") ;;
+        *)  return 0 ;;
+    esac
+    local t
+    if command -v curl >/dev/null 2>&1; then
+        for t in "${cands[@]}"; do
+            if curl -sfI "https://download.pytorch.org/whl/${t}/" >/dev/null 2>&1; then
+                echo "$t"; return 0
+            fi
+        done
+        return 0   # none of the candidates are served
+    fi
+    echo "${cands[0]}"   # cannot probe (no curl) -- assume newest known
+}
+
+# Decide the single CUDA major shared by the pip DL group. Echoes "12", "13"
+# or "cpu". Honours --cuda; otherwise derives it from the driver ceiling
+# intersected with what the *requested* frameworks support:
+#   torch {11,12,13}, jax {12,13}, tf {12}.  Auto-selection is capped at 12
+#   (the universally-supported major); 13 is opt-in via --cuda 13.
+resolve_group_cuda_major() {
+    case "$CUDA_OVERRIDE" in
+        cpu) echo cpu; return 0 ;;
+        12|13)
+            if $INSTALL_TENSORFLOW && [[ "$CUDA_OVERRIDE" == 13 ]]; then
+                die "TensorFlow has no CUDA 13 build; use --cuda 12 or drop --tensorflow."
+            fi
+            local cm; cm=$(driver_cuda_major)
+            if [[ -n "$cm" && "$cm" -lt "$CUDA_OVERRIDE" ]]; then
+                warn "Requested CUDA ${CUDA_OVERRIDE} exceeds the driver ceiling (${cm}.x); wheels may fail to run."
+            fi
+            echo "$CUDA_OVERRIDE"; return 0 ;;
+    esac
+
+    # --- auto ---
+    local cm; cm=$(driver_cuda_major)
+    if [[ -z "$cm" ]]; then
+        echo cpu; return 0            # no GPU/driver -> CPU (expected, no warning)
+    fi
+
+    # Candidate majors, highest-first. 13 only when the driver allows it, no
+    # TensorFlow is requested, and (if torch is requested) a cu13x wheel exists.
+    local -a cand=()
+    [[ "$cm" -ge 13 ]] && ! $INSTALL_TENSORFLOW && cand+=(13)
+    [[ "$cm" -ge 12 ]] && cand+=(12)
+
+    local m
+    for m in "${cand[@]}"; do
+        if $INSTALL_PYTORCH && [[ -z "$(torch_index_tag "$m")" ]]; then
+            continue   # no usable torch wheel for this major
+        fi
+        echo "$m"; return 0
+    done
+
+    warn "NVIDIA driver supports only CUDA ${cm}.x, below what the requested frameworks need for GPU; falling back to CPU builds."
+    echo cpu
+}
+
+# --------------------------------------------------------------------------- #
+# Deep-learning installers
+# --------------------------------------------------------------------------- #
+
+# PyTorch as the sole DL framework: install from conda-forge so it stays part
+# of the conda solve and shares the environment's stack (e.g. with ROOT).
+install_conda_torch() {
+    local -a pkgs=(torchvision torchaudio)
+    case "$CUDA_OVERRIDE" in
+        cpu)
+            pkgs=(pytorch-cpu "${pkgs[@]}") ;;
+        12|13)
+            pkgs=(pytorch-gpu "${pkgs[@]}" "cuda-version=${CUDA_OVERRIDE}.*")
+            if ! has_nvidia_gpu; then
+                export CONDA_OVERRIDE_CUDA="${CUDA_OVERRIDE}.0"
+                warn "No GPU detected; forcing CONDA_OVERRIDE_CUDA=${CONDA_OVERRIDE_CUDA} to build a GPU-capable env (e.g. from a login node)."
+            fi ;;
+        *)
+            if has_nvidia_gpu; then
+                pkgs=(pytorch-gpu "${pkgs[@]}")
+                info "NVIDIA GPU detected -> installing the CUDA build of PyTorch."
+            else
+                pkgs=(pytorch-cpu "${pkgs[@]}")
+                info "No NVIDIA GPU detected -> installing the CPU build of PyTorch."
+            fi ;;
+    esac
+    run conda install -y -c conda-forge "${pkgs[@]}"
+}
+
+# Multiple DL frameworks (or TF/JAX alone): install via pip, last and together,
+# so they all draw from one nvidia-*-cu12 wheel set.
+install_pip_dl() {
+    local major; major=$(resolve_group_cuda_major)
+    info "Deep-learning (pip) CUDA target: ${major}"
+
+    if $INSTALL_PYTORCH; then
+        local tag="cpu"
+        if [[ "$major" != cpu ]]; then
+            tag=$(torch_index_tag "$major")
+            [[ -z "$tag" ]] && { warn "No PyTorch CUDA ${major} wheel available; using the CPU build."; tag=cpu; }
+        fi
+        # --index-url replaces PyPI, so PyTorch must be its own command.
+        run pip --cache-dir "$PIP_CACHE_DIR" install torch torchvision torchaudio \
+            --index-url "https://download.pytorch.org/whl/${tag}"
+    fi
+
+    # TensorFlow + JAX resolve together from PyPI and reuse the wheels above.
+    local -a extras=()
+    if $INSTALL_TENSORFLOW; then
+        [[ "$major" == cpu ]] && extras+=(tensorflow) || extras+=("tensorflow[and-cuda]")
+    fi
+    if $INSTALL_JAX; then
+        [[ "$major" == cpu ]] && extras+=(jax) || extras+=("jax[cuda${major}]")
+    fi
+    if [[ ${#extras[@]} -gt 0 ]]; then
+        run pip --cache-dir "$PIP_CACHE_DIR" install "${extras[@]}"
+    fi
+}
+
+# Verify there is exactly one CUDA stack and the frameworks import cleanly.
+verify_cuda_stack() {
+    info "Verifying CUDA / library consistency"
+
+    if [[ "$DL_MODE" == pip ]]; then
+        local leaked
+        leaked=$(conda list 2>/dev/null \
+            | grep -iE '^(cudatoolkit|cuda-toolkit|cudnn|cuda-version|libcublas|libcudnn|nccl)[[:space:]]' || true)
+        if [[ -n "$leaked" ]]; then
+            warn "conda-provided CUDA packages found alongside pip CUDA wheels -- this risks version-mismatch crashes:"
+            echo "$leaked" >&2
+            warn "Remove them (conda remove <pkg>) or recreate with pip-only CUDA."
+        else
+            info "  OK: conda layer is CUDA-free (single pip CUDA stack)."
+        fi
+        echo "  pip CUDA wheels:"
+        pip list 2>/dev/null | grep -iE '^nvidia-[a-z-]*-cu[0-9]+' || echo "    (none)"
+    fi
+
+    python - <<'PY' || warn "framework import smoke-test reported issues (see above)."
+import importlib
+for mod in ("torch", "tensorflow", "jax"):
+    try:
+        m = importlib.import_module(mod)
+    except Exception:
+        continue
+    v = getattr(m, "__version__", "?")
+    if mod == "torch":
+        print(f"  torch {v}: cuda_build={m.version.cuda} available={m.cuda.is_available()}")
+    elif mod == "tensorflow":
+        try:
+            n = len(m.config.list_physical_devices("GPU"))
+        except Exception:
+            n = "?"
+        print(f"  tensorflow {v}: gpus={n}")
+    elif mod == "jax":
+        try:
+            d = m.devices()[0].platform
+        except Exception:
+            d = "?"
+        print(f"  jax {v}: default_device={d}")
+PY
+}
+
+# Install MadGraph5_aMC@NLO from the official tarball (kept out of conda so it does
+# not pin the environment's Python) and expose the launcher on the env PATH. MG5
+# compiles Fortran on demand, hence the compilers added to the --hep conda group.
+install_madgraph() {
+    local dest="${CONDADIR}/madgraph"
+    local src="${dest}/MG5_aMC_v${MG5_VERSION//./_}"
+
+    if [[ ! -x "${src}/bin/mg5_aMC" ]]; then
+        mkdir -p "$dest"
+        local tgz="${dest}/MG5_aMC_v${MG5_VERSION}.tar.gz"
+
+        if [[ ! -f "$tgz" ]]; then
+            # Launchpad groups files under a milestone folder that is usually
+            # major.minor but occasionally the previous minor (e.g. 3.7.0 shipped
+            # under 3.6.x). Try the likely folders and keep the first that
+            # downloads (a real GET; HEAD probes get rate-limited/404 on Launchpad).
+            local major="${MG5_VERSION%%.*}" minor
+            minor="${MG5_VERSION#"${major}."}"; minor="${minor%%.*}"
+            info "Downloading MadGraph ${MG5_VERSION}..."
+            local ok=false s
+            for s in "${major}.${minor}" "${major}.$((minor - 1))"; do
+                if download "https://launchpad.net/mg5amcnlo/3.0/${s}.x/+download/MG5_aMC_v${MG5_VERSION}.tar.gz" "$tgz"; then
+                    ok=true; break
+                fi
+                rm -f "$tgz"
+            done
+            $ok || die "Could not download MadGraph ${MG5_VERSION} from Launchpad; check --mg5ver."
+        fi
+        info "Extracting MadGraph to ${dest}..."
+        tar -xzpf "$tgz" -C "$dest" || die "MadGraph extraction failed"
+    else
+        info "MadGraph already installed at ${src}."
+    fi
+
+    # Expose the launcher on the active environment's PATH.
+    ln -sf "${src}/bin/mg5_aMC" "${CONDA_PREFIX}/bin/mg5_aMC"
+    info "MadGraph ${MG5_VERSION} available as 'mg5_aMC' (physics libs via its own 'install' command)."
+}
+
+# --------------------------------------------------------------------------- #
+# Main
+# --------------------------------------------------------------------------- #
+main() {
+    # ---- parse arguments ----
     while [[ "$#" -gt 0 ]]; do
         case $1 in
             -d|--dir)
-                if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
-                    CONDADIR=$2
-                    CONDADIR_SET=true
-                    shift
-                else
-                    echo "ERROR: Argument for $1 is missing" >&2
-                    usage
-                    return 1
-                fi
-                ;;    
+                [[ -n "$2" && "${2:0:1}" != "-" ]] || { echo "ERROR: missing value for $1" >&2; usage; exit 1; }
+                CONDADIR="$2"; CONDADIR_SET=true; shift ;;
             -n|--name)
-                if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
-                    CONDA_ENV_NAME=$2
-                    shift
-                else
-                    echo "ERROR: Argument for $1 is missing" >&2
-                    usage
-                    return 1
-                fi
-                ;;
+                [[ -n "$2" && "${2:0:1}" != "-" ]] || { echo "ERROR: missing value for $1" >&2; usage; exit 1; }
+                CONDA_ENV_NAME="$2"; shift ;;
             -p|--python)
-                if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
-                    CONDA_PYTHON_VERSION=$2
-                    shift
-                else
-                    echo "ERROR: Argument for $1 is missing" >&2
-                    usage
-                    return 1
-                fi
-                ;;
-            -r|--root)
-                INSTALL_ROOT=true
-                ;;
+                [[ -n "$2" && "${2:0:1}" != "-" ]] || { echo "ERROR: missing value for $1" >&2; usage; exit 1; }
+                CONDA_PYTHON_VERSION="$2"; shift ;;
+            -r|--root)       INSTALL_ROOT=true ;;
             --rootver)
-                if [ -n "$2" ] && [ "${2:0:1}" != "-" ]; then
-                    ROOT_INSTALL_VERSION=$2
-                    shift
-                else
-                    echo "ERROR: Argument for $1 is missing" >&2
-                    usage
-                    return 1
-                fi
-                ;; 
-            -h|--hep)
-                INSTALL_HEP=true
-                ;;
-            -w|--workflow)
-                INSTALL_WORKFLOW=true
-                ;;
-            -m|--mlbase)
-                INSTALL_MLBASE=true
-                ;;
-            --tensorflow)
-                INSTALL_TENSORFLOW=true
-                ;; 
-            --alkaid)
-                INSTALL_ALKAID=true
-                ;;             
-            *)
-                usage
-                return 1
-                ;;
+                [[ -n "$2" && "${2:0:1}" != "-" ]] || { echo "ERROR: missing value for $1" >&2; usage; exit 1; }
+                ROOT_INSTALL_VERSION="$2"; shift ;;
+            --hep)           INSTALL_HEP=true ;;
+            --mg5ver)
+                [[ -n "$2" && "${2:0:1}" != "-" ]] || { echo "ERROR: missing value for $1" >&2; usage; exit 1; }
+                MG5_VERSION="$2"; shift ;;
+            -m|--mlbase)     INSTALL_MLBASE=true ;;
+            --transfer)      INSTALL_TRANSFER=true ;;
+            --atlas)         INSTALL_ATLAS=true ;;
+            -w|--workflow)   INSTALL_WORKFLOW=true ;;
+            --alkaid)        INSTALL_ALKAID=true ;;
+            --pytorch)       INSTALL_PYTORCH=true ;;
+            --tensorflow)    INSTALL_TENSORFLOW=true ;;
+            --jax)           INSTALL_JAX=true ;;
+            --dl)            INSTALL_PYTORCH=true; INSTALL_TENSORFLOW=true; INSTALL_JAX=true ;;
+            --cuda)
+                [[ -n "$2" && "${2:0:1}" != "-" ]] || { echo "ERROR: missing value for $1" >&2; usage; exit 1; }
+                case "$2" in
+                    auto|12|13|cpu) CUDA_OVERRIDE="$2" ;;
+                    *) die "invalid --cuda value '$2' (expected: auto | 12 | 13 | cpu)" ;;
+                esac
+                shift ;;
+            -h|--help)       usage; exit 0 ;;
+            *) echo "ERROR: unknown option: $1" >&2; usage; exit 1 ;;
         esac
         shift
     done
 
-    if ! $CONDADIR_SET; then
-        echo "Please specify the directory to install conda" >&2
-        usage
-        return 1
-    fi
+    $CONDADIR_SET || { echo "ERROR: -d/--dir is required" >&2; usage; exit 1; }
 
-    SOURCE="${BASH_SOURCE[0]}"
-    while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
-    DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
-    SOURCE="$(readlink "$SOURCE")"
-    [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
-    done
+    detect_platform
 
-    export DIR="$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )"
-
-    create_conda
-    if [ $? -ne 0 ]; then
-        return 1
-    fi
-    source "${CONDADIR}/miniconda/etc/profile.d/conda.sh"
-    configure_conda
-    if [ -d "${CONDADIR}/miniconda/envs/${CONDA_ENV_NAME}" ]; then
-        echo "INFO: Conda environment $CONDA_ENV_NAME already exists. Skip creation."
-    else
-        conda create -y -c conda-forge --name "$CONDA_ENV_NAME" python="$CONDA_PYTHON_VERSION" 
-    fi
-
-
-    # Add conda clean command to clear cache and prevent lock issues
-    conda clean -y --all
-    echo "INFO: Cleaned conda cache to prevent lock issues."
-    
-    conda activate "$CONDA_ENV_NAME"
-
-    #install TensorFlow
-    if $INSTALL_TENSORFLOW; then
-        pip install tensorflow[and-cuda]
-    fi
-    
-    # install ROOT
-    if $INSTALL_ROOT; then
-        if [ "$ROOT_INSTALL_VERSION" = "latest" ]; then
-            conda install -y -c conda-forge root
+    # ---- deep-learning install mode ----
+    # torch alone  -> conda; torch+others or tf/jax -> pip; else none.
+    DL_MODE=none
+    if $INSTALL_PYTORCH || $INSTALL_TENSORFLOW || $INSTALL_JAX; then
+        if $INSTALL_PYTORCH && ! $INSTALL_TENSORFLOW && ! $INSTALL_JAX; then
+            DL_MODE=conda-torch
         else
-            conda install -y -c conda-forge root==$ROOT_INSTALL_VERSION
+            DL_MODE=pip
         fi
     fi
 
-    if $INSTALL_HEP; then
-        conda install -y -c conda-forge delphes
-	pip --cache-dir "$PIP_CACHE_DIR" install fastjet
-    fi
+    local conda_base="${CONDADIR}/miniforge3"
 
-    PIP_CACHE_DIR=${CONDADIR}/.cache/pip
+    # ---- base install & environment ----
+    install_miniforge "$conda_base"
+    # shellcheck source=/dev/null
+    source "${conda_base}/etc/profile.d/conda.sh" || die "cannot source conda.sh"
+    configure_conda
+
+    if [[ -d "${conda_base}/envs/${CONDA_ENV_NAME}" ]]; then
+        info "Environment '${CONDA_ENV_NAME}' already exists; skipping creation."
+    else
+        run conda create -y -c conda-forge --name "$CONDA_ENV_NAME" python="$CONDA_PYTHON_VERSION"
+    fi
+    conda activate "$CONDA_ENV_NAME" || die "cannot activate ${CONDA_ENV_NAME}"
+
+    PIP_CACHE_DIR="${CONDADIR}/.cache/pip"
     mkdir -p "$PIP_CACHE_DIR"
-    
-    # basic packages
-    conda install -y -c conda-forge pip gh glab
-    pip --cache-dir "$PIP_CACHE_DIR" install pyyaml numpy scipy matplotlib pandas h5py
-    conda install -y -c conda-forge twine jupyterlab jupyterhub
-    conda install -y -c conda-forge numba ruff click
-    pip --cache-dir "$PIP_CACHE_DIR" install pyarrow fsspec tables sympy tqdm
-    # jupyter extensions
-    pip --cache-dir "$PIP_CACHE_DIR" install jupyterlab-nvdashboard jupyterlab-favorites
 
-    # ROOT related packages
+    # ---- stage A: ROOT first (heaviest constraints) ----
     if $INSTALL_ROOT; then
-        pip --cache-dir "$PIP_CACHE_DIR" install awkward uproot vector
+        if [[ "$ROOT_INSTALL_VERSION" == latest ]]; then
+            run conda install -y -c conda-forge root
+        else
+            run conda install -y -c conda-forge "root==${ROOT_INSTALL_VERSION}"
+        fi
     fi
 
-    # install basic ML packages
+    # ---- stage B: base scientific stack + requested conda groups, one solve ----
+    local -a conda_pkgs=(
+        numpy scipy pandas matplotlib h5py pyyaml
+        pyarrow fsspec pytables sympy tqdm numba
+        jupyterlab jupyterhub ruff click pytest
+        pip twine gh glab
+    )
+    $INSTALL_ROOT     && conda_pkgs+=(uproot awkward vector hist mplhep)
+    $INSTALL_HEP      && conda_pkgs+=(delphes pythia8 fortran-compiler cxx-compiler make meson ninja)
+    $INSTALL_MLBASE   && conda_pkgs+=(scikit-learn scikit-optimize hyperopt)
+    $INSTALL_TRANSFER && conda_pkgs+=(rclone globus-cli openssh)
+    $INSTALL_ATLAS    && conda_pkgs+=(rucio-clients gfal2 gfal2-util python-gfal2)
+
+    run conda install -y -c conda-forge "${conda_pkgs[@]}"
+
+    # ---- stage C: PyTorch via conda (only when it is the sole DL framework) ----
+    [[ "$DL_MODE" == conda-torch ]] && install_conda_torch
+
+    # ---- stage D: pip (multi-framework DL group, then pip-only extras) ----
+    [[ "$DL_MODE" == pip ]] && install_pip_dl
+
+    if $INSTALL_HEP; then
+        run pip --cache-dir "$PIP_CACHE_DIR" install fastjet
+        install_madgraph
+    fi
+
     if $INSTALL_MLBASE; then
-        conda install -y -c conda-forge scikit-learn scikit-optimize hyperopt
-        pip --cache-dir "$PIP_CACHE_DIR" install xgboost nflows shapely ray ray[tune]
-        pip --cache-dir "$PIP_CACHE_DIR" install torch torchvision torchaudio
-    fi
-
-    # install Alkaid's packages
-    if $INSTALL_ALKAID; then
-        pip --cache-dir "$PIP_CACHE_DIR" install quickstats aliad colstore
-        #pip install quple
+        run pip --cache-dir "$PIP_CACHE_DIR" install xgboost nflows shapely "ray[tune]"
     fi
 
     if $INSTALL_WORKFLOW; then
-        pip --cache-dir "$PIP_CACHE_DIR" install law
-        #pip install quple
+        run pip --cache-dir "$PIP_CACHE_DIR" install law
     fi
 
-    pip --cache-dir "$PIP_CACHE_DIR" cache purge
+    # jupyter extensions (not on conda-forge as a consistent set)
+    run pip --cache-dir "$PIP_CACHE_DIR" install jupyterlab-nvdashboard jupyterlab-favorites
 
-    #conda install -y -c conda-forge pytorch tensorflow
-    #conda install -c conda-forge tensorflow-gpu==2.12.1
-    #conda install -c "nvidia/label/cuda-11.8.0" cuda-toolkit
-    #conda install -c conda-forge tensorflow-gpu==2.9.0
-    #conda install -c "nvidia/label/cuda-11.7.0" cuda-toolkit
-    #pip install tensorflow[and-cuda]
-    #conda install -c conda-forge cudatoolkit=11.8 cudnn=8.7.0
+    if $INSTALL_ALKAID; then
+        run pip --cache-dir "$PIP_CACHE_DIR" install quickstats aliad colstore
+    fi
+
+    pip --cache-dir "$PIP_CACHE_DIR" cache purge >/dev/null 2>&1 || true
+
+    # ---- verify & clean ----
+    [[ "$DL_MODE" != none ]] && verify_cuda_stack
+
+    run conda clean -y --all
+    info "Cleaned conda cache."
+
+    echo
+    info "Done. Environment '${CONDA_ENV_NAME}' is ready."
+    info "Activate it with:"
+    echo "    source ${conda_base}/etc/profile.d/conda.sh && conda activate ${CONDA_ENV_NAME}"
 }
 
-main "$@"
+# Only run when executed directly, so the functions can be sourced for testing.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/environment/create_conda_environment.sh
+++ b/environment/create_conda_environment.sh
@@ -321,7 +321,8 @@ verify_cuda_stack() {
     if [[ "$DL_MODE" == pip ]]; then
         local leaked
         leaked=$(conda list 2>/dev/null \
-            | grep -iE '^(cudatoolkit|cuda-toolkit|cudnn|cuda-version|libcublas|libcudnn|nccl)[[:space:]]' || true)
+            | grep -iE '^(cudatoolkit|cuda-toolkit|cudnn|cuda-version|libcublas|libcudnn|nccl)[[:space:]]' \
+            | awk '$NF != "pypi"' || true)
         if [[ -n "$leaked" ]]; then
             warn "conda-provided CUDA packages found alongside pip CUDA wheels -- this risks version-mismatch crashes:"
             echo "$leaked" >&2
@@ -333,7 +334,9 @@ verify_cuda_stack() {
         pip list 2>/dev/null | grep -iE '^nvidia-[a-z-]*-cu[0-9]+' || echo "    (none)"
     fi
 
-    python - <<'PY' || warn "framework import smoke-test reported issues (see above)."
+    # cap TF/JAX GPU-memory grabbing so the shared-process smoke test doesn't OOM.
+    TF_FORCE_GPU_ALLOW_GROWTH=true XLA_PYTHON_CLIENT_PREALLOCATE=false \
+        python - <<'PY' || warn "framework import smoke-test reported issues (see above)."
 import importlib
 for mod in ("torch", "tensorflow", "jax"):
     try:

--- a/environment/create_conda_environment.sh
+++ b/environment/create_conda_environment.sh
@@ -387,7 +387,14 @@ install_madgraph() {
             $ok || die "Could not download MadGraph ${MG5_VERSION} from Launchpad; check --mg5ver."
         fi
         info "Extracting MadGraph to ${dest}..."
-        tar -xzpf "$tgz" -C "$dest" || die "MadGraph extraction failed"
+        # The MG5 tarball is packed on macOS and carries com.apple.* xattr pax
+        # headers; GNU tar prints a harmless "Ignoring unknown extended header
+        # keyword" line for each. Silence those on GNU tar (BSD tar lacks the
+        # option and does not warn).
+        local tar_opts=(-xzpf)
+        tar --version 2>/dev/null | grep -q 'GNU tar' \
+            && tar_opts=(--warning=no-unknown-keyword "${tar_opts[@]}")
+        tar "${tar_opts[@]}" "$tgz" -C "$dest" || die "MadGraph extraction failed"
     else
         info "MadGraph already installed at ${src}."
     fi

--- a/environment/test_conda_environment.sh
+++ b/environment/test_conda_environment.sh
@@ -1,0 +1,261 @@
+#!/bin/bash
+#
+# test_conda_environment.sh
+#
+# Acceptance test for create_conda_environment.sh, meant to be run on a real
+# GPU machine. It (optionally) runs the installer, then validates that the
+# resulting environment is correct:
+#
+#   * the environment exists and activates;
+#   * every installed deep-learning framework actually sees and uses the GPU;
+#   * there is exactly ONE CUDA stack (no conda/pip mix, no duplicate majors);
+#   * the requested science/grid packages import.
+#
+# It logs the total time taken (install + validation) and the storage used by
+# the environment and the Miniforge base.
+#
+# Usage:
+#   # install with framework flags, time it, then validate + measure:
+#   ./test_conda_environment.sh -d ~/conda -n gputest -- --pytorch --tensorflow --jax
+#
+#   # validate + measure an environment that already exists:
+#   ./test_conda_environment.sh -d ~/conda -n gputest --validate-only
+#
+# Everything after `--` is forwarded verbatim to create_conda_environment.sh
+# (with -d/-n added automatically).
+
+set -o pipefail
+
+CONDA_ENV_NAME="envbase"
+CONDADIR=""
+CONDADIR_SET=false
+VALIDATE_ONLY=false
+FORWARD=()
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+die()  { echo "ERROR: $*" >&2; exit 1; }
+info() { echo "INFO: $*"; }
+warn() { echo "WARNING: $*" >&2; }
+
+PASS=0
+FAIL=0
+# check <ok?0/1> <label>
+check() {
+    if [[ "$1" -eq 0 ]]; then
+        echo "  PASS  $2"; PASS=$((PASS + 1))
+    else
+        echo "  FAIL  $2"; FAIL=$((FAIL + 1))
+    fi
+}
+
+usage() {
+    cat <<EOF
+Usage: $0 -d DIR [-n NAME] [--validate-only] [-- <installer flags>]
+
+  -d, --dir DIR      Conda base directory (same as the installer's -d) [required]
+  -n, --name NAME    Environment name (default: $CONDA_ENV_NAME)
+      --validate-only  Skip running the installer; validate an existing env
+  -h, --help         Show this help
+  --                 Forward the remaining flags to create_conda_environment.sh
+EOF
+}
+
+# --------------------------------------------------------------------------- #
+# Main
+# --------------------------------------------------------------------------- #
+main() {
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            -d|--dir)  [[ -n "$2" ]] || die "missing value for $1"; CONDADIR="$2"; CONDADIR_SET=true; shift ;;
+            -n|--name) [[ -n "$2" ]] || die "missing value for $1"; CONDA_ENV_NAME="$2"; shift ;;
+            --validate-only) VALIDATE_ONLY=true ;;
+            -h|--help) usage; exit 0 ;;
+            --) shift; FORWARD=("$@"); break ;;
+            *) die "unknown argument: $1 (put installer flags after --)" ;;
+        esac
+        shift
+    done
+    $CONDADIR_SET || { usage; die "-d/--dir is required"; }
+
+    local script_dir base env_dir conda_sh installer
+    script_dir="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+    installer="${script_dir}/create_conda_environment.sh"
+    base="${CONDADIR}/miniforge3"
+    env_dir="${base}/envs/${CONDA_ENV_NAME}"
+    conda_sh="${base}/etc/profile.d/conda.sh"
+
+    # ---- 1. install (timed) ----
+    local install_secs=0
+    if ! $VALIDATE_ONLY; then
+        [[ -f "$installer" ]] || die "installer not found: $installer"
+        info "Running installer: $installer -d $CONDADIR -n $CONDA_ENV_NAME ${FORWARD[*]}"
+        SECONDS=0
+        bash "$installer" -d "$CONDADIR" -n "$CONDA_ENV_NAME" "${FORWARD[@]}" \
+            || die "installer failed"
+        install_secs=$SECONDS
+        info "Install completed in ${install_secs}s."
+    fi
+
+    # ---- 2. activate ----
+    [[ -f "$conda_sh" ]] || die "conda not found at ${base} (did the install run?)"
+    # shellcheck source=/dev/null
+    source "$conda_sh" || die "cannot source ${conda_sh}"
+    [[ -d "$env_dir" ]] || die "environment '${CONDA_ENV_NAME}' not found at ${env_dir}"
+    conda activate "$CONDA_ENV_NAME" || die "cannot activate ${CONDA_ENV_NAME}"
+
+    SECONDS=0
+    echo
+    echo "==================== VALIDATION ===================="
+    check 0 "environment '${CONDA_ENV_NAME}' activates ($(python --version 2>&1))"
+
+    # ---- 3. GPU visibility ----
+    local expect_gpu=0
+    if command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi -L >/dev/null 2>&1; then
+        expect_gpu=1
+        local ceil
+        ceil=$(nvidia-smi 2>/dev/null | sed -n 's/.*CUDA Version:[[:space:]]*\([0-9.]*\).*/\1/p' | head -1)
+        info "GPU present; driver CUDA ceiling: ${ceil:-unknown}"
+    else
+        warn "No NVIDIA GPU detected — running CPU-only validation (framework GPU checks will be informational)."
+    fi
+
+    # ---- 4. single CUDA stack ----
+    local conda_torch pip_nvidia conda_cuda
+    conda_torch=$(conda list 2>/dev/null | grep -cE '^pytorch[[:space:]]')
+    pip_nvidia=$(pip list 2>/dev/null | grep -icE '^nvidia-[a-z0-9-]*-cu[0-9]+')
+    conda_cuda=$(conda list 2>/dev/null \
+        | grep -iE '^(cudatoolkit|cuda-toolkit|cudnn|cuda-version|libcublas|libcudnn|nccl)[[:space:]]' || true)
+
+    if [[ "$conda_torch" -gt 0 ]]; then
+        info "CUDA mode: conda (PyTorch from conda-forge)."
+        # conda CUDA deps are expected here; a stray pip CUDA stack is the fault.
+        check "$([[ "$pip_nvidia" -eq 0 ]] && echo 0 || echo 1)" \
+            "no rogue pip nvidia-*-cu* wheels alongside conda PyTorch (found: ${pip_nvidia})"
+    elif [[ "$pip_nvidia" -gt 0 ]]; then
+        info "CUDA mode: pip (framework wheels provide CUDA)."
+        # conda layer must contribute no CUDA.
+        if [[ -n "$conda_cuda" ]]; then
+            echo "$conda_cuda" | sed 's/^/      /'
+            check 1 "conda layer is CUDA-free (mixed conda+pip CUDA is a resolution hazard)"
+        else
+            check 0 "conda layer is CUDA-free"
+        fi
+        # exactly one CUDA major across the pip wheels.
+        local majors nmaj
+        majors=$(pip list 2>/dev/null | grep -iE '^nvidia-[a-z0-9-]*-cu[0-9]+' \
+            | grep -oE 'cu[0-9]+' | sort -u)
+        nmaj=$(printf '%s\n' "$majors" | grep -c .)
+        check "$([[ "$nmaj" -le 1 ]] && echo 0 || echo 1)" \
+            "single CUDA major across pip wheels ($(echo $majors | tr '\n' ' '))"
+    else
+        info "No CUDA stack present (CPU-only or no DL frameworks)."
+    fi
+
+    # ---- 5. framework functional tests ----
+    EXPECT_GPU="$expect_gpu" python - <<'PY'
+import os, sys
+expect_gpu = os.environ.get("EXPECT_GPU") == "1"
+failures = 0
+
+def report(name, ok, detail):
+    global failures
+    tag = "PASS" if ok else "FAIL"
+    if not ok:
+        failures += 1
+    print(f"  {tag}  {name}: {detail}")
+
+# ---- PyTorch ----
+try:
+    import torch
+    avail = torch.cuda.is_available()
+    if avail:
+        x = torch.randn(2048, 2048, device="cuda")
+        _ = (x @ x).sum().item()
+        torch.cuda.synchronize()
+        detail = (f"cuda_build={torch.version.cuda} cudnn={torch.backends.cudnn.version()} "
+                  f"device={torch.cuda.get_device_name(0)} matmul=ok")
+    else:
+        detail = f"cuda_build={torch.version.cuda} cuda.is_available()=False"
+    report("torch", (avail or not expect_gpu), detail)
+except ModuleNotFoundError:
+    pass
+except Exception as e:
+    report("torch", False, f"{type(e).__name__}: {e}")
+
+# ---- TensorFlow ----
+try:
+    import tensorflow as tf
+    gpus = tf.config.list_physical_devices("GPU")
+    if gpus:
+        with tf.device("/GPU:0"):
+            a = tf.random.normal((2048, 2048))
+            _ = tf.reduce_sum(tf.linalg.matmul(a, a)).numpy()
+        detail = f"gpus={len(gpus)} matmul=ok"
+    else:
+        detail = "no GPU devices visible"
+    report("tensorflow", (bool(gpus) or not expect_gpu), f"{tf.__version__}: {detail}")
+except ModuleNotFoundError:
+    pass
+except Exception as e:
+    report("tensorflow", False, f"{type(e).__name__}: {e}")
+
+# ---- JAX ----
+try:
+    import jax, jax.numpy as jnp
+    devs = jax.devices()
+    plats = {d.platform for d in devs}
+    on_gpu = any(p in ("gpu", "cuda", "rocm") for p in plats)
+    if on_gpu:
+        a = jnp.ones((2048, 2048))
+        _ = float(jnp.dot(a, a).sum())
+        detail = f"devices={plats} dot=ok"
+    else:
+        detail = f"devices={plats} (CPU)"
+    report("jax", (on_gpu or not expect_gpu), f"{jax.__version__}: {detail}")
+except ModuleNotFoundError:
+    pass
+except Exception as e:
+    report("jax", False, f"{type(e).__name__}: {e}")
+
+sys.exit(1 if failures else 0)
+PY
+    check $? "deep-learning frameworks use the GPU (or none installed / CPU-only)"
+
+    # ---- 6. import sanity for other groups (non-fatal) ----
+    echo "  -- optional package imports (informational) --"
+    local mod
+    for mod in numpy scipy pandas h5py uproot awkward vector ROOT rucio gfal2; do
+        if python -c "import ${mod}" >/dev/null 2>&1; then
+            echo "     ok: ${mod}"
+        fi
+    done
+    for bin in rclone globus rucio; do
+        command -v "$bin" >/dev/null 2>&1 && echo "     ok: ${bin} (cli)"
+    done
+
+    local validate_secs=$SECONDS
+
+    # ---- 7. storage & summary ----
+    local env_size base_size
+    env_size=$(du -sh "$env_dir" 2>/dev/null | cut -f1)
+    base_size=$(du -sh "$base" 2>/dev/null | cut -f1)
+
+    echo
+    echo "==================== SUMMARY ===================="
+    echo "  Environment : ${CONDA_ENV_NAME}"
+    $VALIDATE_ONLY || echo "  Install time: ${install_secs}s"
+    echo "  Validate time: ${validate_secs}s"
+    $VALIDATE_ONLY || echo "  Total time  : $((install_secs + validate_secs))s"
+    echo "  Env storage : ${env_size:-?}  (${env_dir})"
+    echo "  Base storage: ${base_size:-?}  (${base})"
+    echo "  Checks      : ${PASS} passed, ${FAIL} failed"
+    echo "================================================"
+
+    [[ "$FAIL" -eq 0 ]] || exit 1
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/environment/test_conda_environment.sh
+++ b/environment/test_conda_environment.sh
@@ -126,7 +126,8 @@ main() {
     conda_torch=$(conda list 2>/dev/null | grep -cE '^pytorch[[:space:]]')
     pip_nvidia=$(pip list 2>/dev/null | grep -icE '^nvidia-[a-z0-9-]*-cu[0-9]+')
     conda_cuda=$(conda list 2>/dev/null \
-        | grep -iE '^(cudatoolkit|cuda-toolkit|cudnn|cuda-version|libcublas|libcudnn|nccl)[[:space:]]' || true)
+        | grep -iE '^(cudatoolkit|cuda-toolkit|cudnn|cuda-version|libcublas|libcudnn|nccl)[[:space:]]' \
+        | awk '$NF != "pypi"' || true)
 
     if [[ "$conda_torch" -gt 0 ]]; then
         info "CUDA mode: conda (PyTorch from conda-forge)."
@@ -154,7 +155,10 @@ main() {
     fi
 
     # ---- 5. framework functional tests ----
-    EXPECT_GPU="$expect_gpu" python - <<'PY'
+    # TF grabs the whole GPU on init and JAX preallocates 75%; cap both so the
+    # three frameworks share one GPU in this single process without OOM noise.
+    EXPECT_GPU="$expect_gpu" TF_FORCE_GPU_ALLOW_GROWTH=true XLA_PYTHON_CLIENT_PREALLOCATE=false \
+        python - <<'PY'
 import os, sys
 expect_gpu = os.environ.get("EXPECT_GPU") == "1"
 failures = 0


### PR DESCRIPTION
## Summary

Reworks `environment/create_conda_environment.sh` onto a Miniforge base with a cleaner install order and GPU-aware deep-learning support, extends the `--hep` group with pythia8 and a from-source MadGraph, and adds `environment/test_conda_environment.sh` — a GPU acceptance test. Rebased on current `main`, so it preserves the recently merged `--hep`/`--workflow`/`gh`/`glab`/Python-3.12 additions.

## Motivation

The script targeted a Miniconda base (needing a Terms-of-Service auto-accept workaround for Anaconda's `defaults` channel it never used), PyTorch had no GPU-aware install path, and conda/pip installs were interleaved with the cache cleaned *before* installs. Separately, `--hep` installed MadGraph via conda (`mg5amcnlo`), which is Python ≤3.11 on conda-forge and would drag the whole environment down from the 3.12 default.

## Changes

**Base → Miniforge3.** conda-forge is the default channel (ToS workaround removed); OS/arch selection collapses to `Miniforge3-$(uname)-$(uname -m).sh`. Native Windows is rejected with a WSL pointer.

**Install order for a clean solve.** ROOT first, then one combined conda pass for the base + requested groups, then pip last; cache cleaned at the end. Base scientific packages moved pip→conda for ABI consistency.

**GPU-aware deep learning** via `--pytorch` / `--tensorflow` / `--jax` (and `--dl`):

| Request | Path | CUDA source |
|---|---|---|
| PyTorch alone | conda-forge `pytorch-gpu`/`pytorch-cpu` | conda (single solve) |
| Torch + TF/JAX, or TF/JAX | pip, installed last and together | one shared `nvidia-*-cu12` set |

The CUDA major is derived from the driver ceiling ∩ framework support, with a `--cuda 12|13|cpu` override and an end-of-run assertion that the conda layer stays CUDA-free in pip mode.

**New groups:** `--transfer` (rclone, globus-cli, openssh) and `--atlas` (rucio-clients + gfal2 family).

**`--hep` extended.** Keeps delphes + fastjet, adds **pythia8** (conda) and installs **MadGraph from the official tarball** instead of conda — current MG5 (≥3.6.3) supports Python 3.12/3.13, so the environment keeps its Python rather than being pinned to 3.11 by the conda package. `--mg5ver VER` pins the MadGraph version (default 3.7.2), with a GET-based Launchpad milestone-folder fallback; `fortran-compiler`/`cxx-compiler`/`make`/`meson`/`ninja` are added for MG5's runtime Fortran compilation.

**Acceptance test** (`test_conda_environment.sh`): optionally runs the installer, verifies every installed framework uses the GPU and that exactly one CUDA stack exists, and logs time and storage.

## Testing

- `bash -n` clean on both scripts.
- CUDA decision logic: 20/20 unit cases (mocked `nvidia-smi`/`curl`).
- Full HEP ecosystem (`base + --root + --hep`) dry-run-resolves on conda-forge for **Python 3.10, 3.11, 3.12 and 3.13** (root 6.40, numba 0.65, pythia8 8.312, delphes 3.5 at each).
- MadGraph series/version resolution verified (3.7.2 → 3.7.x; a 3.7.0-style version falls back to 3.6.x; bogus version errors cleanly).
- **Validated end-to-end on a Perlmutter A100 (40 GB):** the full `--dl --hep --mlbase` env builds in ~12.5 min (15 GB, Python 3.12), and torch (CUDA 12.9 / cuDNN 9.2), TensorFlow 2.21 and JAX 0.10.2 all run on the GPU with a single `cu12` stack; ROOT imports.

## Related Issues

Documentation of `environment/` in the README will follow as a separate PR.
