### PR TITLE
[chore] Remove the Miniforge installer artifact after install

### DIFF
--- a/environment/create_conda_environment.sh
+++ b/environment/create_conda_environment.sh
@@ -164,6 +164,9 @@ install_miniforge() {
 
     info "Installing Miniforge to ${prefix}"
     bash "$installer" -b -p "$prefix" || die "Miniforge installation failed"
+
+    # Remove the installer artifact now that the base is installed.
+    rm -f "$installer"
 }
 
 configure_conda() {


### PR DESCRIPTION
## Summary

Deletes the downloaded `Miniforge3-*.sh` installer from the conda directory once the base environment is installed, so it no longer lingers.

## Changes

`install_miniforge` runs `rm -f "$installer"` after the `bash <installer> -b -p` step. Because that step is guarded by `|| die`, a failed install aborts first and leaves the artifact for retry/inspection; it's removed only on success.

## Testing

`bash -n` clean. The change is a single `rm -f` after the guarded install step.
