### PR TITLE
[polish] Genericize --share examples for public release

### DIFF
--- a/environment/create_conda_environment.sh
+++ b/environment/create_conda_environment.sh
@@ -121,7 +121,7 @@ Sharing (opt-in):
                       can be shared read-only: members get read + execute (no
                       write), non-members get nothing, and directories are made
                       setgid so anything added later inherits the group.
-                      (e.g. --share delta_bhvk on NCSA Delta)
+                      (e.g. --share mygroup)
 
 Other:
   -h, --help          Show this help and exit
@@ -514,7 +514,7 @@ protect_install() {
     # chgrp surface an invalid group itself).
     if command -v getent >/dev/null 2>&1; then
         getent group "$group" >/dev/null 2>&1 \
-            || die "group '${group}' does not exist (e.g. use 'delta_bhvk' on NCSA Delta)"
+            || die "group '${group}' does not exist (check the name with 'id -Gn' or 'getent group ${group}')"
     fi
 
     local t


### PR DESCRIPTION
## Summary

De-identification pass for public release. Replaces the cluster/allocation-specific placeholders (`delta_bhvk` on `NCSA Delta`) in `create_conda_environment.sh` with neutral examples, so the script carries no site-specific identifiers.

- `--share` help example: `--share delta_bhvk on NCSA Delta` → `--share mygroup`
- group-not-found error: `use 'delta_bhvk' on NCSA Delta` → `check the name with 'id -Gn' or 'getent group ${group}'` (neutral and more portable)

## Scope

Help and error text only — **no behavioral change**. `bash -n` clean; no `delta_bhvk`/`NCSA`/`Delta` tokens remain.

The `--alkaid` personal-packages flag is intentionally retained per maintainer preference.