### PR TITLE
[env] Add lhapdf to the --hep group

### DIFF
--- a/environment/create_conda_environment.sh
+++ b/environment/create_conda_environment.sh
@@ -93,7 +93,7 @@ Environment:
 Package groups (opt-in):
   -r, --root          ROOT + HEP python ecosystem (uproot, awkward, vector, hist, mplhep)
       --rootver VER   ROOT version (default: $ROOT_INSTALL_VERSION; only with -r)
-      --hep           HEP generators (delphes, pythia8, fastjet; madgraph from source)
+      --hep           HEP generators + libs (delphes, pythia8, lhapdf, fastjet; madgraph from source)
       --mg5ver VER    MadGraph version to install (default: $MG5_VERSION; only with --hep)
   -m, --mlbase        Classical ML stack (scikit-learn, xgboost, ray, ...)
       --transfer      File-transfer tools (rclone, globus-cli, openssh)
@@ -669,7 +669,7 @@ main() {
         pip twine gh glab
     )
     $INSTALL_ROOT     && conda_pkgs+=(uproot awkward vector hist mplhep)
-    $INSTALL_HEP      && conda_pkgs+=(delphes pythia8 fortran-compiler cxx-compiler make meson ninja)
+    $INSTALL_HEP      && conda_pkgs+=(delphes pythia8 lhapdf fortran-compiler cxx-compiler make meson ninja)
     $INSTALL_MLBASE   && conda_pkgs+=(scikit-learn scikit-optimize hyperopt)
     $INSTALL_TRANSFER && conda_pkgs+=(rclone globus-cli openssh)
     $INSTALL_ATLAS    && conda_pkgs+=(rucio-clients gfal2 gfal2-util python-gfal2)


### PR DESCRIPTION
## Summary

Adds **lhapdf** (PDF sets and interpolation) to the `--hep` group of `create_conda_environment.sh`, installed from conda-forge alongside the other `--hep` conda packages so it resolves in the single combined solve.

- `--hep` conda list: `+ lhapdf`
- Help text: `HEP generators + libs (delphes, pythia8, lhapdf, fastjet; madgraph from source)`

## Note

An earlier draft of this branch also added `pyjet` via pip; it was dropped in favour of the maintained `fastjet` (already installed in `--hep`), which covers the same jet-clustering need without the legacy build.

## Testing

`bash -n` clean; `lhapdf` lands in the conda `--hep` stage.