### PR TITLE
[env] Configure MadGraph at install time for out-of-the-box use

### DIFF
--- a/environment/create_conda_environment.sh
+++ b/environment/create_conda_environment.sh
@@ -449,7 +449,96 @@ install_madgraph() {
 
     # Expose the launcher on the active environment's PATH.
     ln -sf "${src}/bin/mg5_aMC" "${CONDA_PREFIX}/bin/mg5_aMC"
-    info "MadGraph ${MG5_VERSION} available as 'mg5_aMC' (physics libs via its own 'install' command)."
+    info "MadGraph ${MG5_VERSION} available as 'mg5_aMC'."
+}
+
+# Set 'key = value' in an MG5 configuration file: replace the active line if
+# one exists, otherwise append. Commented template lines are left untouched.
+# (MG treats a trailing '#' as an inline comment, so disabling a line requires
+# a leading '#'; this helper only ever writes whole active lines.)
+set_mg5_option() {
+    local file="$1" key="$2" value="$3"
+    if grep -qE "^ *${key} *=" "$file" 2>/dev/null; then
+        sed -i.bak "s|^ *${key} *=.*|${key} = ${value}|" "$file" && rm -f "${file}.bak"
+    else
+        echo "${key} = ${value}" >> "$file"
+    fi
+}
+
+# Wire MadGraph to the environment's tools so a (possibly shared, read-only)
+# install works out of the box, with no per-user setup. Doing this at install
+# time -- BEFORE any 'install <tool>' inside MG5 -- also stops MG's tool
+# installer from building private duplicate copies of LHAPDF/Pythia8 as
+# dependencies. Every step is idempotent, so re-runs are cheap no-ops.
+configure_madgraph() {
+    local src="${CONDADIR}/madgraph/MG5_aMC_v${MG5_VERSION//./_}"
+    local cfg="${src}/input/mg5_configuration.txt"
+    local datadir="${CONDA_PREFIX}/share/LHAPDF"
+
+    [[ -f "$cfg" ]] || { warn "MadGraph config not found at ${cfg}; skipping configuration."; return 0; }
+    info "Configuring MadGraph (environment tools, link flags, PDF data)"
+
+    # Never self-update: the install may be shared read-only (--share).
+    set_mg5_option "$cfg" auto_update 0
+    # Use the environment's LHAPDF and Pythia8 rather than MG-private builds.
+    command -v lhapdf-config >/dev/null 2>&1 \
+        && set_mg5_option "$cfg" lhapdf "${CONDA_PREFIX}/bin/lhapdf-config"
+    command -v pythia8-config >/dev/null 2>&1 \
+        && set_mg5_option "$cfg" pythia8_path "${CONDA_PREFIX}"
+
+    # conda's LHAPDF ships only the shared library, and MG links with
+    # gfortran, which does not pull in the C++ runtime on its own; without
+    # this flag every lhapdf-mode build fails at the gensym link with a wall
+    # of 'undefined reference to operator delete / std::runtime_error'.
+    # Patching the template propagates the fix to every future process dir.
+    local mkopts="${src}/Template/LO/Source/make_opts"
+    if [[ -f "$mkopts" ]] && ! grep -q 'llhapdf += -lstdc++' "$mkopts"; then
+        echo 'llhapdf += -lstdc++' >> "$mkopts"
+    fi
+
+    # Seed the environment's PDF datadir: the set index (without which
+    # 'lhapdf install' knows no set names at all) and the default sets MG
+    # references, so 'pdlabel = lhapdf' works with no per-user downloads.
+    if command -v lhapdf >/dev/null 2>&1; then
+        mkdir -p "$datadir"
+        if [[ ! -f "${datadir}/pdfsets.index" ]]; then
+            LHAPDF_DATA_PATH="$datadir" lhapdf update \
+                || warn "could not download pdfsets.index; run 'lhapdf update' later."
+        fi
+        local pdfset
+        for pdfset in NNPDF23_lo_as_0130_qed NNPDF23_nlo_as_0119_qed; do
+            [[ -d "${datadir}/${pdfset}" ]] && continue
+            LHAPDF_DATA_PATH="$datadir" lhapdf install "$pdfset" \
+                || warn "could not download PDF set ${pdfset}; run 'lhapdf install ${pdfset}' later."
+        done
+    fi
+
+    # Pre-compile the default model cache (models/sm/*.pkl): users of a
+    # read-only shared install cannot write it themselves on first use. Run
+    # from a scratch directory so parser artifacts (py.py) land nowhere real.
+    if ! compgen -G "${src}/models/sm/*.pkl" >/dev/null; then
+        info "Pre-compiling the default MadGraph model (one-time)..."
+        local warmdir; warmdir=$(mktemp -d)
+        ( cd "$warmdir" && echo "exit" | "${src}/bin/mg5_aMC" >/dev/null 2>&1 ) \
+            || warn "model pre-compilation failed; the first run may need write access to ${src}/models."
+        rm -rf "$warmdir"
+    fi
+
+    info "MadGraph configured. For showering inside MadEvent, additionally run 'install mg5amc_py8_interface' in the MG5 prompt once (as the install owner)."
+}
+
+# activate.d hook: per-user PDF sets first, the environment's shared sets
+# second. Users of a read-only install can then 'lhapdf install <set>' into
+# their own directory and LHAPDF finds both. Idempotent (overwrites its file).
+write_lhapdf_activate_hook() {
+    local hookdir="${CONDA_PREFIX}/etc/conda/activate.d"
+    mkdir -p "$hookdir" || die "cannot create ${hookdir}"
+    cat > "${hookdir}/lhapdf_data_path.sh" <<EOF
+# Per-user PDF sets first, this environment's shared sets second, so users
+# can install their own sets without write access to the environment.
+export LHAPDF_DATA_PATH="\${HOME}/.local/share/LHAPDF:${CONDA_PREFIX}/share/LHAPDF"
+mkdir -p "\${HOME}/.local/share/LHAPDF"
+EOF
 }
 
 # --------------------------------------------------------------------------- #
@@ -693,6 +782,8 @@ main() {
     if $INSTALL_HEP; then
         run pip --cache-dir "$PIP_CACHE_DIR" install fastjet
         install_madgraph
+        configure_madgraph
+        write_lhapdf_activate_hook
     fi
 
     if $INSTALL_MLBASE; then

--- a/environment/create_conda_environment.sh
+++ b/environment/create_conda_environment.sh
@@ -524,7 +524,98 @@ configure_madgraph() {
         rm -rf "$warmdir"
     fi
 
-    info "MadGraph configured. For showering inside MadEvent, additionally run 'install mg5amc_py8_interface' in the MG5 prompt once (as the install owner)."
+    info "MadGraph configured."
+}
+
+# Verify that a built MG5aMC-PY8 interface links Pythia8/HepMC/LHAPDF from
+# the environment rather than a private build. ldd is the ground truth for
+# the wiring; on platforms without it the check is skipped.
+verify_py8_interface() {
+    local exe="$1" ifdir
+    ifdir=$(dirname "$exe")
+    # compile.py stamps the Pythia8 version it built against; a mismatch with
+    # the environment means the interface is stale (e.g. Pythia8 upgraded).
+    if [[ -f "${ifdir}/PYTHIA8_VERSION_ON_INSTALL" ]] && command -v pythia8-config >/dev/null 2>&1; then
+        local built have
+        built=$(cat "${ifdir}/PYTHIA8_VERSION_ON_INSTALL")
+        have=$(pythia8-config --version 2>/dev/null)
+        [[ -n "$have" && "$built" != "$have" ]] \
+            && warn "interface built against Pythia8 ${built} but the environment has ${have}; rebuild it after Pythia8 upgrades."
+    fi
+    command -v ldd >/dev/null 2>&1 || { info "ldd unavailable; skipping interface link check."; return 0; }
+    local bad
+    bad=$(ldd "$exe" 2>/dev/null | grep -iE "pythia|hepmc|lhapdf" | grep -v "${CONDA_PREFIX}/lib" || true)
+    if [[ -n "$bad" ]]; then
+        warn "MG5aMC_PY8_interface links libraries from outside the environment:"
+        echo "$bad" >&2
+    else
+        info "  OK: interface links Pythia8/HepMC from the environment."
+    fi
+}
+
+# Build the MG5aMC-Pythia8 interface (required for shower=Pythia8 inside
+# MadEvent) against the environment's Pythia8. configure_madgraph has already
+# set pythia8_path/lhapdf, which is what makes MG's installer reuse the conda
+# tools instead of building private copies. conda's Pythia8 links HepMC2 as a
+# shared library only, which the default interface build can reject (it
+# assumes a static HepMC2), so fall back to the interface's own compile.py
+# with --pythia8_makefile, which takes the link flags from Pythia8's makefile
+# and links HepMC2 dynamically. Never fatal: parton-level generation does not
+# need the interface.
+install_py8_interface() {
+    local src="${CONDADIR}/madgraph/MG5_aMC_v${MG5_VERSION//./_}"
+    local cfg="${src}/input/mg5_configuration.txt"
+    command -v pythia8-config >/dev/null 2>&1 || return 0
+    [[ -f "$cfg" ]] || return 0
+
+    # Read the configured interface path (strip inline comments; resolve the
+    # MG5-relative form './HEPTools/...').
+    _py8_ifpath() {
+        local p
+        p=$(sed -n 's/^ *mg5amc_py8_interface_path *= *//p' "$cfg" | sed 's/ *#.*//; s/ *$//' | head -1)
+        [[ "$p" == ./* ]] && p="${src}/${p#./}"
+        echo "$p"
+    }
+
+    local ifpath; ifpath=$(_py8_ifpath)
+    if [[ -n "$ifpath" && -x "${ifpath}/MG5aMC_PY8_interface" ]]; then
+        info "MG5aMC-PY8 interface already installed at ${ifpath}."
+        verify_py8_interface "${ifpath}/MG5aMC_PY8_interface"
+        return 0
+    fi
+
+    info "Installing the MG5aMC-Pythia8 interface (for shower=Pythia8)..."
+    local log="${CONDADIR}/madgraph/py8_interface_install.log"
+    printf 'install mg5amc_py8_interface\nexit\n' | "${src}/bin/mg5_aMC" > "$log" 2>&1 || true
+
+    ifpath=$(_py8_ifpath)
+    if [[ -z "$ifpath" || ! -x "${ifpath}/MG5aMC_PY8_interface" ]]; then
+        # Fallback: compile the sources MG already downloaded, linking HepMC2
+        # dynamically via Pythia8's makefile flags. CLI verified against the
+        # interface's compile.py (V1.3): the flag is position-independent,
+        # argv[1] is the Pythia8 root, and argv[2] the MG5 root -- passed
+        # explicitly because the script's built-in '../..' guess is only
+        # right when the interface sits inside the MG5 tree.
+        local d py
+        py=$(command -v python || command -v python3)
+        for d in "${src}/HEPTools/MG5aMC_PY8_interface" "${CONDADIR}/HEPTools/MG5aMC_PY8_interface"; do
+            [[ -n "$py" && -f "${d}/compile.py" ]] || continue
+            info "Default interface build failed; retrying with --pythia8_makefile..."
+            ( cd "$d" && "$py" compile.py --pythia8_makefile "$CONDA_PREFIX" "$src" >> "$log" 2>&1 ) || true
+            if [[ -x "${d}/MG5aMC_PY8_interface" ]]; then
+                set_mg5_option "$cfg" mg5amc_py8_interface_path "$d"
+                ifpath="$d"
+            fi
+            break
+        done
+    fi
+
+    if [[ -n "$ifpath" && -x "${ifpath}/MG5aMC_PY8_interface" ]]; then
+        info "MG5aMC-PY8 interface installed at ${ifpath}."
+        verify_py8_interface "${ifpath}/MG5aMC_PY8_interface"
+    else
+        warn "MG5aMC-PY8 interface build failed (log: ${log}). Parton-level generation is unaffected; for shower=Pythia8, run 'install mg5amc_py8_interface' in the MG5 prompt and consult the log."
+    fi
 }
 
 # activate.d hook: per-user PDF sets first, the environment's shared sets
@@ -783,6 +874,7 @@ main() {
         run pip --cache-dir "$PIP_CACHE_DIR" install fastjet
         install_madgraph
         configure_madgraph
+        install_py8_interface
         write_lhapdf_activate_hook
     fi
 

--- a/environment/create_conda_environment.sh
+++ b/environment/create_conda_environment.sh
@@ -898,7 +898,7 @@ main() {
         pip twine gh glab
     )
     $INSTALL_ROOT     && conda_pkgs+=(uproot awkward vector hist mplhep iminuit particle hepunits pylhe uhi)
-    $INSTALL_HEP      && conda_pkgs+=(delphes pythia8 sherpa evtgen lhapdf hepmc2 hepmc3 rivet yoda fortran-compiler cxx-compiler make meson ninja)
+    $INSTALL_HEP      && conda_pkgs+=(delphes pythia8 sherpa evtgen lhapdf hepmc2 hepmc3 rivet yoda fortran-compiler cxx-compiler make meson ninja gnuplot)
     $INSTALL_GEANT4   && conda_pkgs+=(geant4)
     $INSTALL_MLBASE   && conda_pkgs+=(scikit-learn scikit-optimize hyperopt)
     $INSTALL_TRANSFER && conda_pkgs+=(rclone globus-cli openssh)

--- a/environment/create_conda_environment.sh
+++ b/environment/create_conda_environment.sh
@@ -65,6 +65,10 @@ TORCH_CU13_TAGS=(cu130)
 # Override the version with --mg5ver.
 MG5_VERSION="3.7.2"
 
+# MG5aMC-Pythia8 interface release, for the direct-download fallback when MG's
+# own installer never fetched the sources.
+PY8_INTERFACE_VERSION="1.3"
+
 # --------------------------------------------------------------------------- #
 # Helpers
 # --------------------------------------------------------------------------- #
@@ -96,7 +100,7 @@ Package groups (opt-in):
                       iminuit, particle, hepunits, pylhe, uhi)
       --rootver VER   ROOT version (default: $ROOT_INSTALL_VERSION; only with -r)
       --hep           HEP generators + libs (delphes, pythia8, sherpa, evtgen, lhapdf,
-                      fastjet, hepmc3, rivet/yoda; madgraph from source)
+                      fastjet, hepmc2/3, rivet/yoda; madgraph from source)
       --mg5ver VER    MadGraph version to install (default: $MG5_VERSION; only with --hep)
       --geant4        Geant4 detector-simulation toolkit (heavy: Qt6 + multi-GB data)
   -m, --mlbase        Classical ML stack (scikit-learn, xgboost, ray, ...)
@@ -554,14 +558,15 @@ verify_py8_interface() {
 }
 
 # Build the MG5aMC-Pythia8 interface (required for shower=Pythia8 inside
-# MadEvent) against the environment's Pythia8. configure_madgraph has already
-# set pythia8_path/lhapdf, which is what makes MG's installer reuse the conda
-# tools instead of building private copies. conda's Pythia8 links HepMC2 as a
-# shared library only, which the default interface build can reject (it
-# assumes a static HepMC2), so fall back to the interface's own compile.py
-# with --pythia8_makefile, which takes the link flags from Pythia8's makefile
-# and links HepMC2 dynamically. Never fatal: parton-level generation does not
-# need the interface.
+# MadEvent) against the environment's Pythia8, in three tiers: MG's own
+# installer (configure_madgraph has already set pythia8_path/lhapdf, which is
+# what makes it reuse the conda tools instead of building private copies),
+# then the interface's compile.py with --pythia8_makefile, then a direct
+# compile against the environment's pythia8 + hepmc2 -- the tier that works
+# with conda's Pythia8, which is built without HepMC2 in its makefile config
+# and whose examples Makefile (>= 8.310) no longer wires HepMC into the
+# main89 target the earlier tiers depend on. Never fatal: parton-level
+# generation does not need the interface.
 install_py8_interface() {
     local src="${CONDADIR}/madgraph/MG5_aMC_v${MG5_VERSION//./_}"
     local cfg="${src}/input/mg5_configuration.txt"
@@ -603,6 +608,45 @@ install_py8_interface() {
             info "Default interface build failed; retrying with --pythia8_makefile..."
             ( cd "$d" && "$py" compile.py --pythia8_makefile "$CONDA_PREFIX" "$src" >> "$log" 2>&1 ) || true
             if [[ -x "${d}/MG5aMC_PY8_interface" ]]; then
+                set_mg5_option "$cfg" mg5amc_py8_interface_path "$d"
+                ifpath="$d"
+            fi
+            break
+        done
+    fi
+
+    # Last resort: compile the interface directly. Both routes above fail with
+    # conda's Pythia8: it is built without HepMC2 in its makefile config (so
+    # the default build's static-HepMC check dies), and Pythia >= 8.310
+    # renumbered away the main89 example target that --pythia8_makefile builds
+    # through. The Pythia8Plugins HepMC2 glue is header-only, so a direct
+    # compile against the environment's pythia8 + hepmc2 (both in the --hep
+    # group) is deterministic and depends on neither makefile.
+    if [[ -z "$ifpath" || ! -x "${ifpath}/MG5aMC_PY8_interface" ]] \
+        && [[ -f "${CONDA_PREFIX}/include/HepMC/IO_BaseClass.h" ]]; then
+        local dl="${src}/HEPTools/MG5aMC_PY8_interface" cxx
+        cxx=${CXX:-$(command -v c++ || command -v g++)}
+        # MG's installer may have failed before ever fetching the sources.
+        if [[ ! -f "${dl}/MG5aMC_PY8_interface.cc" \
+              && ! -f "${CONDADIR}/HEPTools/MG5aMC_PY8_interface/MG5aMC_PY8_interface.cc" ]]; then
+            mkdir -p "$dl"
+            download "https://madgraph.mi.infn.it/Downloads/MG5aMC_PY8_interface/MG5aMC_PY8_interface_V${PY8_INTERFACE_VERSION}.tar.gz" \
+                     "${dl}/iface.tar.gz" \
+                && tar -xzf "${dl}/iface.tar.gz" -C "$dl" && rm -f "${dl}/iface.tar.gz"
+        fi
+        for d in "$dl" "${CONDADIR}/HEPTools/MG5aMC_PY8_interface"; do
+            [[ -n "$cxx" && -f "${d}/MG5aMC_PY8_interface.cc" ]] || continue
+            info "Compiling the interface directly against the environment's Pythia8 + HepMC2..."
+            ( cd "$d" && "$cxx" MG5aMC_PY8_interface.cc -o MG5aMC_PY8_interface \
+                -O2 -std=c++11 -fPIC -pthread -DGZIP \
+                -I"${CONDA_PREFIX}/include" -L"${CONDA_PREFIX}/lib" \
+                -Wl,-rpath,"${CONDA_PREFIX}/lib" -lpythia8 -lHepMC -lz -ldl >> "$log" 2>&1 ) || true
+            if [[ -x "${d}/MG5aMC_PY8_interface" ]]; then
+                # stamps compile.py would have written, kept honest for the
+                # version-drift check in verify_py8_interface
+                pythia8-config --version > "${d}/PYTHIA8_VERSION_ON_INSTALL" 2>/dev/null || true
+                sed -n 's/^ *version *= *//p' "${src}/VERSION" 2>/dev/null | head -1 \
+                    > "${d}/MG5AMC_VERSION_ON_INSTALL" || true
                 set_mg5_option "$cfg" mg5amc_py8_interface_path "$d"
                 ifpath="$d"
             fi
@@ -854,7 +898,7 @@ main() {
         pip twine gh glab
     )
     $INSTALL_ROOT     && conda_pkgs+=(uproot awkward vector hist mplhep iminuit particle hepunits pylhe uhi)
-    $INSTALL_HEP      && conda_pkgs+=(delphes pythia8 sherpa evtgen lhapdf hepmc3 rivet yoda fortran-compiler cxx-compiler make meson ninja)
+    $INSTALL_HEP      && conda_pkgs+=(delphes pythia8 sherpa evtgen lhapdf hepmc2 hepmc3 rivet yoda fortran-compiler cxx-compiler make meson ninja)
     $INSTALL_GEANT4   && conda_pkgs+=(geant4)
     $INSTALL_MLBASE   && conda_pkgs+=(scikit-learn scikit-optimize hyperopt)
     $INSTALL_TRANSFER && conda_pkgs+=(rclone globus-cli openssh)


### PR DESCRIPTION
## Summary

Encodes, once and for all, the wiring a shared (read-only) MadGraph install needs so users can generate — and shower — events out of the box. Every item below corresponds to a real failure debugged by hand on a production cluster deployment, now automated and verified at install time.

## What `--hep` installs now do

**`configure_madgraph`** (runs right after the tarball install):
- `auto_update = 0`, and `lhapdf`/`pythia8_path` pointed at the environment's tools in `input/mg5_configuration.txt`. Setting `lhapdf` *before* any MG-side `install <tool>` also stops MG's installer from building a private duplicate LHAPDF as a dependency.
- `llhapdf += -lstdc++` appended to the `make_opts` template — conda's LHAPDF is shared-lib-only and MG links with gfortran, so lhapdf-mode builds otherwise die at the gensym link with walls of undefined C++ references.
- LHAPDF datadir seeded with `pdfsets.index` (without it `lhapdf install` knows no set names) and MG's default NNPDF23 sets.
- Default model cache pre-compiled from a scratch directory — no first-use writes into a read-only tree, no stray `py.py` parser artifacts.
- An `activate.d` hook exporting `LHAPDF_DATA_PATH` with a per-user directory first, so users install their own PDF sets without env write access.

**`install_py8_interface`** (three tiers, never fatal, idempotent):
1. MG's own `install mg5amc_py8_interface` — reuses the conda tools because the options above are already set.
2. The interface's `compile.py --pythia8_makefile` (CLI verified against the published V1.3 source; MG5 root passed explicitly since its `../..` guess fails outside the MG tree).
3. **Direct compile** against the env's pythia8 + hepmc2 — the tier that works with conda's Pythia8, which is built without HepMC2 makefile support and whose ≥ 8.310 examples Makefile no longer wires HepMC into the `main89` target the earlier tiers depend on. Self-downloads the interface sources if MG never fetched them, and writes the `PYTHIA8/MG5AMC_VERSION_ON_INSTALL` stamps.

The built interface is verified two ways: `ldd` (every Pythia8/HepMC/LHAPDF dependency must resolve into the environment) and the Pythia8 version stamp against `pythia8-config --version` (stale-after-upgrade detection).

**Package group additions:** `hepmc2` (required by the interface) and `gnuplot` (MG's merging/DJR plots) join `--hep`.

## Validation

- Every configuration step unit-tested against a stubbed MG tree: config rewrites (commented template lines untouched), idempotent re-runs, datadir seeding, scratch-dir model warmup, hook contents, all three interface tiers including the direct-compile flags, stamps, and config registration.
- The tier-3 route and end state were validated live on a production deployment: interface rebuilt against conda's Pythia8, `ldd` resolving into the env, and a 100-event `shower=Pythia8` run producing HepMC output with the Pythia banner matching the env version.