### PR TITLE
[env] Refuse to run check_hep_env.sh via source

### DIFF
--- a/diagnostics/check_hep_env.sh
+++ b/diagnostics/check_hep_env.sh
@@ -29,6 +29,13 @@
 #
 # Exit code: 0 all checks pass, 1 warnings only, 2 at least one failure.
 
+# Refuse to be sourced: the script ends with 'exit', which would close the
+# caller's shell, and it never needs to modify the calling environment.
+if [[ "${BASH_SOURCE[0]:-}" != "$0" ]]; then
+    echo "check_hep_env.sh: run this script directly (it exits with a status code); do not source it." >&2
+    return 1
+fi
+
 set -o pipefail
 
 FAST=false


### PR DESCRIPTION
## Summary

`check_hep_env.sh` reports its result through `exit`, so `source`-ing it terminated the caller's shell — an easy mistake to make, and the first-user experience on a production deployment.

## Fix

The script never needs to modify the calling environment, so instead of making every exit path return-safe, it now detects sourcing at the top (`BASH_SOURCE[0]` vs `$0`) and bails out with a one-line notice and `return 1` — legal only in a sourced context, which is exactly that branch — leaving the shell alive. The guard also triggers when sourced from zsh, where `BASH_SOURCE` is unset.

## Testing

- `bash -c 'source …'` and `zsh -c 'source …'`: notice printed, shell survives, `rc=1`.
- Direct execution unchanged (`--help`, full run, exit codes intact).