### PR TITLE
[env] Stop the diagnostics run littering py.py into the working directory

### DIFF
--- a/diagnostics/check_hep_env.sh
+++ b/diagnostics/check_hep_env.sh
@@ -239,7 +239,11 @@ else
     # Effective options as MG itself resolves them (slow path).
     if ! $FAST && [[ -n "$MG5_BIN" ]]; then
         section "MadGraph effective options (display options)"
-        MG5_OUT=$(printf 'display options\nexit\n' | mg5_aMC 2>&1)
+        # Run MG5 from a scratch directory: its PLY parser drops generated
+        # files (py.py) into the current working directory.
+        MG5_TMP=$(mktemp -d)
+        MG5_OUT=$( cd "$MG5_TMP" && printf 'display options\nexit\n' | mg5_aMC 2>&1 )
+        rm -rf "$MG5_TMP"
         echo "$MG5_OUT" | grep -iE "^\s+(lhapdf|lhapdf_py2|lhapdf_py3|pythia8_path|mg5amc_py8_interface_path|auto_update)\s+:" \
             | sed 's/^[[:space:]]*/  /'
         while IFS= read -r bad; do


### PR DESCRIPTION
## Summary

Every diagnostics run left a stray `py.py` in the invocation directory. The effective-options section pipes `display options` into `mg5_aMC`, and MG5's PLY parser writes its generated table cache into the current working directory — the same mechanism previously observed littering a shared project root when MG5 was launched from arbitrary directories.

## Fix

The MG5 invocation now runs from a `mktemp` scratch directory (the same guard `create_conda_environment.sh` uses for the model warm-up), removed afterwards. The script stays true to its read-only contract.

## Testing

Stub `mg5_aMC` mimicking the PLY behavior (writes `py.py` into its cwd, prints an options line): the effective-options section still renders, and the invocation directory stays clean after the run. `bash -n` clean.

Existing stray `py.py` files from earlier runs are regenerable caches and safe to delete.